### PR TITLE
Fix family method check

### DIFF
--- a/R/SampleSplitSuperLearner.R
+++ b/R/SampleSplitSuperLearner.R
@@ -84,7 +84,10 @@ SampleSplitSuperLearner <- function(Y, X, newX = NULL, family = gaussian(), SL.l
 		print(family)
 		stop("'family' not recognized")
 	}
-	
+  if (family$family != "binomial" & ifelse(is.null(method$require), FALSE, method$require == "cvAUC")){
+    stop("'method.AUC' is designed for the 'binomial' family only")
+  }  
+  
   # test id
 	if(is.null(id)) {
 		id <- seq(N)

--- a/R/SuperLearner.R
+++ b/R/SuperLearner.R
@@ -72,7 +72,6 @@ SuperLearner <- function(Y, X, newX = NULL, family = gaussian(), SL.library, met
 		print(family)
 		stop("'family' not recognized")
 	}
-	
 	if (family$family != "binomial" & ifelse(is.null(method$require), FALSE, method$require == "cvAUC")){
 		stop("'method.AUC' is designed for the 'binomial' family only")
 	}

--- a/R/mcSuperLearner.R
+++ b/R/mcSuperLearner.R
@@ -73,7 +73,6 @@ mcSuperLearner <- function(Y, X, newX = NULL, family = gaussian(), SL.library, m
 		print(family)
 		stop("'family' not recognized")
 	}
-	
   if (family$family != "binomial" & ifelse(is.null(method$require), FALSE, method$require == "cvAUC")){
     stop("'method.AUC' is designed for the 'binomial' family only")
   }

--- a/R/snowSuperLearner.R
+++ b/R/snowSuperLearner.R
@@ -74,7 +74,6 @@ snowSuperLearner <- function(cluster, Y, X, newX = NULL, family = gaussian(), SL
 		print(family)
 		stop("'family' not recognized")
 	}
-	
   if (family$family != "binomial" & ifelse(is.null(method$require), FALSE, method$require == "cvAUC")){
     stop("'method.AUC' is designed for the 'binomial' family only")
   }


### PR DESCRIPTION
This fixes a bug introduced in the last merge.  There was an error that occurred when using metalearning methods that do not have required packages (e.g. method.NNloglik) while family = binomial().  This also adds the same family & method check to SampleSplitSuperLearner because it had not been added previously.
