### PR TITLE
Fix bartMachine documentation

### DIFF
--- a/man/SL.bartMachine.Rd
+++ b/man/SL.bartMachine.Rd
@@ -25,7 +25,7 @@ SL.bartMachine(Y, X, newX, family, obsWeights, id, num_trees = 50,
 
 \item{nu}{Degrees of freedom for the inverse χ^2 prior. Not used for classification.}
 
-\item{num_iterations_after_burn_in}{Number of MCMC samples to draw from the posterior distribution of \hat{f}(x).}
+\item{num_iterations_after_burn_in}{Number of MCMC samples to draw from the posterior distribution of f(x).}
 }
 \description{
 Support bayesian additive regression trees via the bartMachine package.

--- a/man/predict.SL.bartMachine.Rd
+++ b/man/predict.SL.bartMachine.Rd
@@ -4,8 +4,7 @@
 \alias{predict.SL.bartMachine}
 \title{bartMachine prediction}
 \usage{
-\method{predict}{SL.bartMachine}(object, newdata, family, X = NULL,
-  Y = NULL, ...)
+predict.SL.bartMachine(object, newdata, family, X = NULL, Y = NULL, ...)
 }
 \description{
 bartMachine prediction


### PR DESCRIPTION
Hi,

This is a minor fix for two lingering documentation tweaks for bartMachine, the main one being that \hat issue (was fixed in the R file, now also fixed in the Rd file).

Thanks,
Chris