### PR TITLE
Appveyor CI (code via devtools)

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -4,3 +4,4 @@
 ^\.travis\.yml$
 ^.*\.Rproj$
 ^\.Rproj\.user$
+^appveyor\.yml$

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,61 @@
+# DO NOT CHANGE the "init" and "install" sections below
+
+# Download script file from GitHub
+init:
+  ps: |
+        $ErrorActionPreference = "Stop"
+        Invoke-WebRequest http://raw.github.com/krlmlr/r-appveyor/master/scripts/appveyor-tool.ps1 -OutFile "..\appveyor-tool.ps1"
+        Import-Module '..\appveyor-tool.ps1'
+install:
+  ps: Bootstrap
+
+# Adapt as necessary starting from here
+
+build_script:
+  - git config --global user.name "travis"
+  - git config --global user.email "travis@example.org"
+  - Rscript -e "source('http://bioconductor.org/biocLite.R')"
+  - travis-tool.sh install_deps
+  - travis-tool.sh github_package jimhester/covr
+
+test_script:
+  - travis-tool.sh run_tests
+
+on_failure:
+  - 7z a failure.zip *.Rcheck\*
+  - appveyor PushArtifact failure.zip
+
+on_success:
+  - Rscript -e 'covr::codecov()'
+
+environment:
+  global:
+    WARNINGS_ARE_ERRORS: 1
+    _R_CHECK_FORCE_SUGGESTS_: 0
+    R_ARCH: x64
+    USE_RTOOLS: true ## to be able to use Remotes (i.e. packages from non-CRAN sources)
+
+  matrix:
+    - R_VERSION: release
+
+artifacts:
+  - path: '*.Rcheck\**\*.log'
+    name: Logs
+
+  - path: '*.Rcheck\**\*.out'
+    name: Logs
+
+  - path: '*.Rcheck\**\*.fail'
+    name: Logs
+
+  - path: '*.Rcheck\**\*.Rout'
+    name: Logs
+
+  - path: '\*_*.tar.gz'
+    name: Bits
+
+  - path: '\*_*.zip'
+    name: Bits
+
+cache:
+  - C:\RLibrary


### PR DESCRIPTION
Hi,

This adds supports for Appveyor CI. It's similar to travis except it seems to run about twice as fast (so we get failures faster), runs on windows (good for testing), and has some different customization features. I think it will also be beneficial to have a second CI service for times when the other service is down.

Eric, the other step would be for you to connect your github account at http://www.appveyor.com/ and add SuperLearner as a project. Then it should automatically process commits & PRs like travis-ci.

Here is an example build: https://ci.appveyor.com/project/ck37/superlearner/build/1.0.2

Thanks,
Chris