### PR TITLE
Time SuperLearner execution; add simple test

### DIFF
--- a/R/snowSuperLearner.R
+++ b/R/snowSuperLearner.R
@@ -2,7 +2,14 @@
 #
 #  Created by Eric Polley on 2011-04-19.
 #
-snowSuperLearner <- function(cluster, Y, X, newX = NULL, family = gaussian(), SL.library, method = 'method.NNLS', id = NULL, verbose = FALSE, control = list(), cvControl = list(), obsWeights = NULL, env = parent.frame()) {
+snowSuperLearner <- function(cluster, Y, X, newX = NULL, family = gaussian(), SL.library,
+                             method = 'method.NNLS', id = NULL, verbose = FALSE,
+                             control = list(), cvControl = list(), obsWeights = NULL,
+                             env = parent.frame()) {
+
+  # Begin timing how long SuperLearner takes to execute.
+  time_start = proc.time()
+
   .SL.require('parallel')
   if (!inherits(cluster, 'cluster')) stop('\'cluster\' must be a cluster created using the makeCluster() function in the snow package')
   if (is.character(method)) {
@@ -142,21 +149,25 @@ snowSuperLearner <- function(cluster, Y, X, newX = NULL, family = gaussian(), SL
   # additional steps to put things in the correct order
   # rbind unlists the output from lapply
   # need to unlist folds to put the rows back in the correct order
-	Z[unlist(validRows, use.names = FALSE), ] <- do.call('rbind', parallel::parLapply(cl = cluster, X = validRows, fun = .crossValFUN, Y = Y, dataX = X, id = id, obsWeights = obsWeights, library = library, kScreen = kScreen, k = k, p = p, libraryNames = libraryNames, verbose = verbose))
+	time_train = system.time({
+	  Z[unlist(validRows, use.names = FALSE), ] <- do.call('rbind', parallel::parLapply(cl = cluster, X = validRows, fun = .crossValFUN, Y = Y, dataX = X, id = id, obsWeights = obsWeights, library = library, kScreen = kScreen, k = k, p = p, libraryNames = libraryNames, verbose = verbose))
 
-  # check for errors. If any algorithms had errors, replace entire column with 0 even if error is only in one fold.
-  errorsInCVLibrary <- apply(Z, 2, function(x) any(is.na(x)))
-  if(sum(errorsInCVLibrary) > 0) {
-		Z[, as.logical(errorsInCVLibrary)] <- 0
-	}
-	if(all(Z == 0)) {
-		stop("All algorithms dropped from library")
-	}
+	  # Check for errors. If any algorithms had errors, replace entire column with
+	  # 0 even if error is only in one fold.
+	  errorsInCVLibrary <- apply(Z, 2, function(x) any(is.na(x)))
+    if(sum(errorsInCVLibrary) > 0) {
+		  Z[, as.logical(errorsInCVLibrary)] <- 0
+	  }
+	  if(all(Z == 0)) {
+		  stop("All algorithms dropped from library")
+	  }
 
-  # compute weights for each algorithm in library:
-  getCoef <- method$computeCoef(Z = Z, Y = Y, libraryNames = libraryNames, obsWeights = obsWeights, control = control, verbose = verbose)
-  coef <- getCoef$coef
-  names(coef) <- libraryNames
+    # Compute weights for each algorithm in library.
+    getCoef <- method$computeCoef(Z = Z, Y = Y, libraryNames = libraryNames, obsWeights = obsWeights, control = control, verbose = verbose)
+    coef <- getCoef$coef
+    names(coef) <- libraryNames
+
+	}) # Finish timing.
 
   # Set a default in case the method does not return the optimizer result.
   if(!("optimizer" %in% names(getCoef))) {
@@ -179,82 +190,121 @@ snowSuperLearner <- function(cluster, Y, X, newX = NULL, family = gaussian(), SL
   	}
     return(out)
   }
-  if (length(library$screenAlgorithm) < 2) {
-   whichScreen <- t(sapply(library$screenAlgorithm, FUN = .screenFun, list = list(Y = Y, X = X, family = family, id = id, obsWeights = obsWeights)))
-  } else {
-    whichScreen <- t(parallel::parSapply(cl = cluster, X = library$screenAlgorithm, FUN = .screenFun, list = list(Y = Y, X = X, family = family, id = id, obsWeights = obsWeights)))
-	}
-  # change to sapply?
-  # for(s in 1:k) {
-  #   testAlg <- try(do.call(library$library$predAlgorithm[s], list(Y = Y, X = subset(X, select = whichScreen[library$library$rowScreen[s], ], drop=FALSE), newX = subset(newX, select = whichScreen[library$library$rowScreen[s], ], drop=FALSE), family = family, id = id, obsWeights = obsWeights)))
-  #   if(inherits(testAlg, "try-error")) {
-  #     warning(paste("Error in algorithm", library$library$predAlgorithm[s], " on full data", "\n  The Algorithm will be removed from the Super Learner (i.e. given weight 0) \n" ))
-  #     errorsInLibrary[s] <- 1
-  #   } else {
-  #     predY[, s] <- testAlg$pred
-  #   }
-  #   if(control$saveFitLibrary) {
-  #     fitLibrary[[s]] <- testAlg$fit
-  #   }
-  #   if(verbose) {
-  #     message(paste("full", libraryNames[s]))
-  #   }
-  # }
-  .predFun <- function(index, lib, Y, dataX, newX, whichScreen, family, id, obsWeights, verbose, control, libraryNames) {
-    out <- list(pred = NA, fitLibrary = NULL)
-    pred_fn = get(lib$predAlgorithm[index], envir = env)
-    testAlg <- try(do.call(pred_fn, list(Y = Y, X = subset(dataX, select = whichScreen[lib$rowScreen[index], ], drop=FALSE), newX = subset(newX, select = whichScreen[lib$rowScreen[index], ], drop=FALSE), family = family, id = id, obsWeights = obsWeights)))
-    if(inherits(testAlg, "try-error")) {
-      warning(paste("Error in algorithm", lib$predAlgorithm[index], " on full data", "\n  The Algorithm will be removed from the Super Learner (i.e. given weight 0) \n" ))
-      out$pred <- rep.int(NA, times = nrow(newX))
+
+  time_predict = system.time({
+
+    if (length(library$screenAlgorithm) < 2) {
+      whichScreen <- t(sapply(library$screenAlgorithm, FUN = .screenFun, list = list(Y = Y, X = X, family = family, id = id, obsWeights = obsWeights)))
     } else {
-      out$pred <- testAlg$pred
-      if(control$saveFitLibrary) {
-        # eval(bquote(fitLibrary[[.(index)]] <- .(testAlg$fit)), envir = fitLibEnv)
-        out$fitLibrary <- testAlg$fit
+      whichScreen <- t(parallel::parSapply(cl = cluster, X = library$screenAlgorithm, FUN = .screenFun, list = list(Y = Y, X = X, family = family, id = id, obsWeights = obsWeights)))
+    }
+    # change to sapply?
+    # for(s in 1:k) {
+    #   testAlg <- try(do.call(library$library$predAlgorithm[s], list(Y = Y, X = subset(X, select = whichScreen[library$library$rowScreen[s], ], drop=FALSE), newX = subset(newX, select = whichScreen[library$library$rowScreen[s], ], drop=FALSE), family = family, id = id, obsWeights = obsWeights)))
+    #   if(inherits(testAlg, "try-error")) {
+    #     warning(paste("Error in algorithm", library$library$predAlgorithm[s], " on full data", "\n  The Algorithm will be removed from the Super Learner (i.e. given weight 0) \n" ))
+    #     errorsInLibrary[s] <- 1
+    #   } else {
+    #     predY[, s] <- testAlg$pred
+    #   }
+    #   if(control$saveFitLibrary) {
+    #     fitLibrary[[s]] <- testAlg$fit
+    #   }
+    #   if(verbose) {
+    #     message(paste("full", libraryNames[s]))
+    #   }
+    # }
+    .predFun <- function(index, lib, Y, dataX, newX, whichScreen, family, id, obsWeights, verbose, control, libraryNames) {
+      out <- list(pred = NA, fitLibrary = NULL)
+      pred_fn = get(lib$predAlgorithm[index], envir = env)
+      testAlg <- try(do.call(pred_fn, list(Y = Y, X = subset(dataX, select = whichScreen[lib$rowScreen[index], ], drop=FALSE), newX = subset(newX, select = whichScreen[lib$rowScreen[index], ], drop=FALSE), family = family, id = id, obsWeights = obsWeights)))
+      if(inherits(testAlg, "try-error")) {
+        warning(paste("Error in algorithm", lib$predAlgorithm[index], " on full data", "\n  The Algorithm will be removed from the Super Learner (i.e. given weight 0) \n" ))
+        out$pred <- rep.int(NA, times = nrow(newX))
+      } else {
+        out$pred <- testAlg$pred
+        if(control$saveFitLibrary) {
+          # eval(bquote(fitLibrary[[.(index)]] <- .(testAlg$fit)), envir = fitLibEnv)
+          out$fitLibrary <- testAlg$fit
+        }
+      }
+      if(verbose) {
+        message(paste("full", libraryNames[index]))
+      }
+      invisible(out)
+    }
+
+
+    foo <- parallel::parLapply(cl = cluster, X = seq(k), fun = .predFun, lib = library$library, Y = Y, dataX = X, newX = newX, whichScreen = whichScreen, family = family, id = id, obsWeights = obsWeights, verbose = verbose, control = control, libraryNames = libraryNames)
+    predY <- do.call('cbind', lapply(foo, '[[', 'pred'))
+    assign('fitLibrary', lapply(foo, '[[', 'fitLibrary'), envir = fitLibEnv)
+    rm(foo)
+
+    # predY <- do.call('cbind', parLapply(cluster, seq(k), fun = .predFun, lib = library$library, Y = Y, dataX = X, newX = newX, whichScreen = whichScreen, family = family, id = id, obsWeights = obsWeights, verbose = verbose, control = control, libraryNames = libraryNames))
+
+    # check for errors
+    errorsInLibrary <- apply(predY, 2, function(xx) any(is.na(xx)))
+    if(sum(errorsInLibrary) > 0) {
+      if(sum(coef[as.logical(errorsInLibrary)]) > 0) {
+        warning(paste("re-running estimation of coefficients removing failed algorithm(s) \n Orignial coefficients are: \n", coef, "\n"))
+        Z[, as.logical(errorsInLibrary)] <- 0
+        if(all(Z == 0)) {
+          stop("All algorithms dropped from library")
+        }
+        getCoef <- method$computeCoef(Z = Z, Y = Y, libraryNames = libraryNames, obsWeights = obsWeights, control = control, verbose = verbose)
+        coef <- getCoef$coef
+        names(coef) <- libraryNames
+      } else {
+        warning("coefficients already 0 for all failed algorithm(s)")
       }
     }
-    if(verbose) {
-      message(paste("full", libraryNames[index]))
-    }
-    invisible(out)
-  }
-  foo <- parallel::parLapply(cl = cluster, X = seq(k), fun = .predFun, lib = library$library, Y = Y, dataX = X, newX = newX, whichScreen = whichScreen, family = family, id = id, obsWeights = obsWeights, verbose = verbose, control = control, libraryNames = libraryNames)
-  predY <- do.call('cbind', lapply(foo, '[[', 'pred'))
-  assign('fitLibrary', lapply(foo, '[[', 'fitLibrary'), envir = fitLibEnv)
-  rm(foo)
 
-  # predY <- do.call('cbind', parLapply(cluster, seq(k), fun = .predFun, lib = library$library, Y = Y, dataX = X, newX = newX, whichScreen = whichScreen, family = family, id = id, obsWeights = obsWeights, verbose = verbose, control = control, libraryNames = libraryNames))
+    # Compute super learner predictions on newX.
+    getPred <- method$computePred(predY = predY, coef = coef, control = control)
 
-  # check for errors
-  errorsInLibrary <- apply(predY, 2, function(xx) any(is.na(xx)))
-	if(sum(errorsInLibrary) > 0) {
-		if(sum(coef[as.logical(errorsInLibrary)]) > 0) {
-			warning(paste("re-running estimation of coefficients removing failed algorithm(s) \n Orignial coefficients are: \n", coef, "\n"))
-			Z[, as.logical(errorsInLibrary)] <- 0
-			if(all(Z == 0)) {
-				stop("All algorithms dropped from library")
-			}
-      getCoef <- method$computeCoef(Z = Z, Y = Y, libraryNames = libraryNames, obsWeights = obsWeights, control = control, verbose = verbose)
-      coef <- getCoef$coef
-      names(coef) <- libraryNames
-		} else {
-			warning("coefficients already 0 for all failed algorithm(s)")
-		}
-	}
+  }) # Finish timing.
 
-  # compute super learner predictions on newX
-	getPred <- method$computePred(predY = predY, coef = coef, control = control)
-
-	# add names of algorithms to the predictions
+	# Add names of algorithms to the predictions.
 	colnames(predY) <- libraryNames
-	# clean up when errors in library
+
+	# Clean up when errors in library.
 	if(sum(errorsInCVLibrary) > 0) {
 		getCoef$cvRisk[as.logical(errorsInCVLibrary)] <- NA
 	}
 
-  # put everything together in a list
-  out <- list(call = call, libraryNames = libraryNames, SL.library = library, SL.predict = getPred, coef = coef, library.predict = predY, Z = Z, cvRisk = getCoef$cvRisk, family = family, fitLibrary = get('fitLibrary', envir = fitLibEnv), id = id, varNames = varNames, validRows = validRows, method = method, whichScreen = whichScreen, control = control, errorsInCVLibrary = errorsInCVLibrary, errorsInLibrary = errorsInLibrary, obsWeights = obsWeights, metaOptimizer = getCoef$optimizer)
+	# Finish timing the full SuperLearner execution.
+	time_end = proc.time()
+
+	# Compile execution times.
+	times = list(everything = time_end - time_start,
+	             train = time_train,
+	             predict = time_predict)
+
+  # Put everything together in a list.
+	out <- list(
+	    call = call,
+	    libraryNames = libraryNames,
+	    SL.library = library,
+	    SL.predict = getPred,
+	    coef = coef,
+	    library.predict = predY,
+	    Z = Z,
+	    cvRisk = getCoef$cvRisk,
+	    family = family,
+	    fitLibrary = get('fitLibrary', envir = fitLibEnv),
+	    id = id,
+	    varNames = varNames,
+	    validRows = validRows,
+	    method = method,
+	    whichScreen = whichScreen,
+	    control = control,
+	    errorsInCVLibrary = errorsInCVLibrary,
+	    errorsInLibrary = errorsInLibrary,
+	    obsWeights = obsWeights,
+	    metaOptimizer = getCoef$optimizer,
+	    env = env,
+	    times = times
+	  )
 	class(out) <- c("SuperLearner")
 	return(out)
 }

--- a/man/SuperLearner.Rd
+++ b/man/SuperLearner.Rd
@@ -118,6 +118,9 @@ A logical vector indicating if any algorithms experienced an error on the full d
   \item{env}{
   Environment passed into function which will be searched to find the learner functions. Defaults to the calling environment.
   }
+  \item{times}{
+  A list that contains the execution time of the SuperLearner, plus separate times for model fitting and prediction.
+  }
 }
 
 \references{

--- a/tests/testthat/test_SuperLearner.R
+++ b/tests/testthat/test_SuperLearner.R
@@ -1,0 +1,21 @@
+########################
+# Simulate data
+set.seed(23432)
+# Create small training set for quick tests.
+n <- 80
+p <- 6
+X <- data.frame(matrix(rnorm(n * p), nrow = n, ncol = p))
+colnames(X) <- paste0("X", 1:p)
+gen_y = function(x) x[, 1] + sqrt(abs(x[, 2] * x[, 3])) + x[, 2] - x[, 3] + rnorm(nrow(x))
+Y <- gen_y(X)
+summary(Y)
+
+
+########################
+# Run the SuperLearner
+models = c("SL.randomForest", "SL.glmnet", "SL.glm", "SL.mean")
+cv_control = SuperLearner.CV.control(V = 4L)
+sl = SuperLearner(Y, X, SL.library = models, cvControl = cv_control)
+sl
+# Check execution times
+sl$times


### PR DESCRIPTION
Hi,

This is a quick patch to time how long SuperLearner takes to execute, as a convenience to analysts. Caret does this in essentially the same way: https://github.com/topepo/caret/blob/master/pkg/caret/R/train.default.R#L617

This also adds a basic test of the SuperLearner function.

Per JSM I'll work to time each individual algorithm, which would be especially useful, but that will take more thought.

Thanks,
Chris