### PR TITLE
Add env argument to CV.SuperLearner()

### DIFF
--- a/R/CV.SuperLearner.R
+++ b/R/CV.SuperLearner.R
@@ -1,6 +1,6 @@
 # V-fold Cross-validation wrapper for SuperLearner
 
-CV.SuperLearner <- function(Y, X, V = 20, family = gaussian(), SL.library, method = 'method.NNLS', id = NULL, verbose = FALSE, control = list(saveFitLibrary = FALSE), cvControl = list(), obsWeights = NULL, saveAll = TRUE, parallel = "seq") {
+CV.SuperLearner <- function(Y, X, V = 20, family = gaussian(), SL.library, method = 'method.NNLS', id = NULL, verbose = FALSE, control = list(saveFitLibrary = FALSE), cvControl = list(), obsWeights = NULL, saveAll = TRUE, parallel = "seq", env = parent.frame()) {
   call <- match.call()
   N <- dim(X)[1L]
   
@@ -53,7 +53,7 @@ CV.SuperLearner <- function(Y, X, V = 20, family = gaussian(), SL.library, metho
     cvId <- id[-valid]
     cvObsWeights <- obsWeights[-valid]
     
-    fit.SL <- SuperLearner(Y = cvOutcome, X = cvLearn, newX = cvValid, family = family, SL.library = SL.library, method = method, id = cvId, verbose = verbose, control = control, cvControl = cvControl, obsWeights = cvObsWeights)
+    fit.SL <- SuperLearner(Y = cvOutcome, X = cvLearn, newX = cvValid, family = family, SL.library = SL.library, method = method, id = cvId, verbose = verbose, control = control, cvControl = cvControl, obsWeights = cvObsWeights, env = env)
     
     out <- list(cvAllSL = if(saveAll) fit.SL, cvSL.predict = fit.SL$SL.predict, cvdiscreteSL.predict = fit.SL$library.predict[, which.min(fit.SL$cvRisk)], cvwhichDiscreteSL = names(which.min(fit.SL$cvRisk)), cvlibrary.predict = fit.SL$library.predict, cvcoef = fit.SL$coef)
     return(out)

--- a/man/CV.SuperLearner.Rd
+++ b/man/CV.SuperLearner.Rd
@@ -13,7 +13,7 @@ Function to get V-fold cross-validated risk estimate for super learner. This fun
 CV.SuperLearner(Y, X, V = 20, family = gaussian(), SL.library,
   method = "method.NNLS", id = NULL, verbose = FALSE,
   control = list(saveFitLibrary = FALSE), cvControl = list(),
-  obsWeights = NULL, saveAll = TRUE, parallel = "seq")
+  obsWeights = NULL, saveAll = TRUE, parallel = "seq", env = parent.frame())
 }
 
 \arguments{
@@ -55,6 +55,9 @@ Logical; Should the entire \code{SuperLearner} object be saved for each fold?
 }
   \item{parallel}{
 Options for parallel computation of the V-fold step. Use "seq" (the default) for sequential computation. \code{parallel = 'multicore'} to use \code{mclapply} for the V-fold step (but note that \code{SuperLearner()} will still be sequential). The default for mclapply is to check the \code{mc.cores} option, and if not set to default to 2 cores. Be sure to set \code{options()$mc.cores} to the desired number of cores if you don't want the default. Or \code{parallel} can be the name of a snow cluster and will use \code{parLapply} for the V-fold step. For both multicore and snow, the inner \code{SuperLearner} calls will be sequential.
+  }
+  \item{env}{
+  Environment containing the learner functions. Defaults to the calling environment.
   }
 }
 


### PR DESCRIPTION
I found the new `env` argument in `SuperLearner()` useful and would like to also use it with `CV.SuperLearner()`. The addition seemed straightforward but let me know if I've missed something.