### PR TITLE
Fix Travis build: install survival and xgboost manually

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,15 @@ bioc_packages:
  - sva
  - genefilter
 
+# Install survival directly, to get the latest version and avoid
+# a build error from using an older version.
+r_packages: survival
+
+# Install custom version of xgboost since CRAN is out of date as of 2016-12-09.
+before_install:
+  - Rscript -e 'install.packages("xgboost", repos=c("http://dmlc.ml/drat/", getOption("repos")), type="source")'
+
+
 r_github_packages:
  - jimhester/covr
 after_success:


### PR DESCRIPTION
Hi,

Here is a fix for the Travis build - installing survival and xgboost manually. XGBoost is a little extra work because its CRAN version is very out of date, so it needs to be installed via its custom DRAT repo.

Hopefully XGBoost will update their CRAN release soon: https://github.com/dmlc/xgboost/issues/1812

Cheers,
Chris