### PR TITLE
CV.SuperLearner: innerCvControl argument

### DIFF
--- a/R/CV.SuperLearner.R
+++ b/R/CV.SuperLearner.R
@@ -23,7 +23,7 @@ CV.SuperLearner <- function(Y, X, V = NULL, family = gaussian(), SL.library, met
 		  warning("Only a single innerCvControl is given, will be replicated across all cross-validation split calls to SuperLearner")
 		  newInnerCvControl <- vector("list", cvControl$V)
 		  for(ii in seq(cvControl$V)) {
-			  newInnerCvControl[[ii]] <- innerCvControl
+			  newInnerCvControl[[ii]] <- unlist(innerCvControl, recursive = FALSE)
 		  }
 		  innerCvControl <- newInnerCvControl  # write over previous with replicated list
 	  }

--- a/man/CV.SuperLearner.Rd
+++ b/man/CV.SuperLearner.Rd
@@ -144,7 +144,7 @@ coef(test)
 # CV.SuperLearner (cvControl) and the internal SuperLearners (innerCvControl)
 test <- CV.SuperLearner(Y = Y, X = X, SL.library = SL.library,
   cvControl = list(V = 10, shuffle = FALSE),
-  innerCvControl = list(V = 5),
+  innerCvControl = list(list(V = 5)),
   verbose = TRUE, method = "method.NNLS")
 
 ## examples with snow


### PR DESCRIPTION
The example code provided utilizing the `innerCvControl` argument of `CV.SuperLearner` does not scale to multiple `SuperLearner.CV.control` arguments. For example, if `innerCvControl` is set to `list(V = 5, shuffle = FALSE)` instead of `list(V = 5)`, an error is produced. This is obviously because `innerCvControl` is not of length 1.  However, if `innerCvControl` is instead set to `list(list(V = 5, shuffle = FALSE))`, the resulting list must be nested too deeply, as warnings are produced in each fold: `In 1:V : numerical expression has 2 elements: only the first used`.

The proposed fix alters `CV.SuperLearner` to expect `innerCvControl` to always be a list of lists, even if it is of length 1, and modifies the example given in the docs to match.