### PR TITLE
Fix RF test bug where use of "NULL" requires hyperparameter element is a list rather than a vector

### DIFF
--- a/tests/testthat/test_randomForest.R
+++ b/tests/testthat/test_randomForest.R
@@ -116,7 +116,9 @@ print(sl)
 sl_env = new.env()
 
 # Test maxnode specification, including one version that uses the default.
-tune_rf = list(mtry = c(4, 8), maxnodes = c(5, 10, "NULL"))
+# We specify maxnodes using a list rather than vector so that 5 and 10 are not
+# coerced into strings.
+tune_rf = list(mtry = c(4, 8), maxnodes = list(5, 10, "NULL"))
 create_rf = create.Learner("SL.randomForest", tune = tune_rf, detailed_names = T,
                            env = sl_env)
 print(create_rf)


### PR DESCRIPTION
Hi,

This fixes a minor bug in the RF tests based on the new support for character arguments for hyperparameters in create.Learner(). When we test multiple numeric settings and include "NULL" as an option to test the default, the numeric elements are coerced into strings due to c(). So instead we should use list() which allows the numerics to not be coerced into strings.

I'm not sure why this code didn't already trigger an error in the automated Travis testing - to be investigated in the future. I only ran into it after running devtools::test() locally.

Thanks,
Chris