### PR TITLE
KernelKnn: add example, add gaussian test

### DIFF
--- a/R/SL.kernelKnn.R
+++ b/R/SL.kernelKnn.R
@@ -1,6 +1,7 @@
 #' @title SL wrapper for KernelKNN
 #'
-#' @description Wrapper for a configurable implementation of k-nearest neighbors.
+#' @description Wrapper for a configurable implementation of k-nearest
+#'   neighbors. Supports both binomial and gaussian outcome distributions.
 #' @param Y Outcome variable
 #' @param X Training dataframe
 #' @param newX Test dataframe
@@ -22,6 +23,26 @@
 #' @param ... Any additional parameters, not currently passed through.
 #' @return List with predictions and the original training data &
 #'   hyperparameters.
+#'
+#' @examples
+#'
+#' # Load a test dataset.
+#' data(PimaIndiansDiabetes2, package = "mlbench")
+#'
+#' data = PimaIndiansDiabetes2
+#'
+#' # Omit observations with missing data.
+#' data = na.omit(data)
+#'
+#' Y_bin = as.numeric(data$diabetes)
+#' X = subset(data, select = -diabetes)
+#'
+#' set.seed(1)
+#'
+#' sl = SuperLearner(Y_bin, X, family = binomial(),
+#'                  SL.library = c("SL.mean", "SL.kernelKnn"))
+#' sl
+#'
 #' @export
 SL.kernelKnn = function(Y, X, newX, family,
                         k = 10,

--- a/man/SL.kernelKnn.Rd
+++ b/man/SL.kernelKnn.Rd
@@ -42,5 +42,26 @@ List with predictions and the original training data &
   hyperparameters.
 }
 \description{
-Wrapper for a configurable implementation of k-nearest neighbors.
+Wrapper for a configurable implementation of k-nearest
+  neighbors. Supports both binomial and gaussian outcome distributions.
+}
+\examples{
+
+# Load a test dataset.
+data(PimaIndiansDiabetes2, package = "mlbench")
+
+data = PimaIndiansDiabetes2
+
+# Omit observations with missing data.
+data = na.omit(data)
+
+Y_bin = as.numeric(data$diabetes)
+X = subset(data, select = -diabetes)
+
+set.seed(1)
+
+sl = SuperLearner(Y_bin, X, family = binomial(),
+                 SL.library = c("SL.mean", "SL.kernelKnn"))
+sl
+
 }

--- a/tests/testthat/test_kernelKnn.R
+++ b/tests/testthat/test_kernelKnn.R
@@ -10,15 +10,33 @@ data = PimaIndiansDiabetes2
 # Omit observations with missing data.
 data = na.omit(data)
 
-Y = as.numeric(data$diabetes)
+Y_bin = as.numeric(data$diabetes)
 X = subset(data, select = -diabetes)
 
 set.seed(1)
 
 # Try just the wrapper itself, not via SuperLearner
-knn = SuperLearner::SL.kernelKnn(Y, X, X, family = binomial())
+knn = SuperLearner::SL.kernelKnn(Y_bin, X, X, family = binomial())
 
 # Now try SuperLearner with the wrapper.
-sl = SuperLearner(Y, X, family = binomial(),
+sl = SuperLearner(Y_bin, X, family = binomial(),
                   SL.library = c("SL.mean", "SL.kernelKnn"))
 sl
+
+######
+# Test gaussian() outcome.
+
+Y_gaus = data$glucose
+X = subset(data, select = -glucose)
+X$diabetes = as.numeric(X$diabetes == "pos")
+
+set.seed(1)
+
+# Try just the wrapper itself, not via SuperLearner
+knn = SuperLearner::SL.kernelKnn(Y_gaus, X, X, family = gaussian())
+
+# Now try SuperLearner with the wrapper.
+sl = SuperLearner(Y_gaus, X, family = gaussian(),
+                  SL.library = c("SL.mean", "SL.kernelKnn"))
+sl
+


### PR DESCRIPTION
Hi,

This is a small KernelKnn follow-up - it adds an example to the wrapper documentation, and adds a test of gaussian outcomes.

Thanks,
Chris