### PR TITLE
Control verbosity of SL.ranger, and send to predict() also

### DIFF
--- a/R/SL.ranger.R
+++ b/R/SL.ranger.R
@@ -21,6 +21,7 @@
 #' @param sample.fraction Fraction of observations to sample. Default is 1 for
 #'   sampling with replacement and 0.632 for sampling without replacement.
 #' @param num.threads Number of threads to use.
+#' @param verbose If TRUE, display additional output during execution.
 #' @param ... Any additional arguments, not currently used.
 #'
 #' @examples
@@ -62,6 +63,7 @@ SL.ranger <-
            replace = TRUE,
            sample.fraction = ifelse(replace, 1, 0.632),
            num.threads = 1,
+           verbose = T,
            ...) {
   # need write.forest = TRUE for predict method
   .SL.require("ranger")
@@ -87,7 +89,8 @@ SL.ranger <-
                         case.weights = obsWeights,
                         write.forest = write.forest,
                         probability = probability,
-                        num.threads = num.threads)
+                        num.threads = num.threads,
+                        verbose = verbose)
 
   pred <- predict(fit, data = newX)$predictions
 
@@ -97,7 +100,7 @@ SL.ranger <-
     pred = pred[, "1"]
   }
 
-  fit <- list(object = fit)
+  fit <- list(object = fit, verbose = verbose)
   class(fit) <- c("SL.ranger")
   out <- list(pred = pred, fit = fit)
   return(out)
@@ -120,7 +123,7 @@ SL.ranger <-
 #' @export
 predict.SL.ranger <- function(object, newdata, family,
                               num.threads = 1,
-                              verbose = F,
+                              verbose = object$verbose,
                               ...) {
   .SL.require("ranger")
 

--- a/man/SL.ranger.Rd
+++ b/man/SL.ranger.Rd
@@ -8,7 +8,8 @@ SL.ranger(Y, X, newX, family, obsWeights, num.trees = 500,
   mtry = floor(sqrt(ncol(X))), write.forest = TRUE,
   probability = family$family == "binomial",
   min.node.size = ifelse(family$family == "gaussian", 5, 1), replace = TRUE,
-  sample.fraction = ifelse(replace, 1, 0.632), num.threads = 1, ...)
+  sample.fraction = ifelse(replace, 1, 0.632), num.threads = 1,
+  verbose = T, ...)
 }
 \arguments{
 \item{Y}{Outcome variable}
@@ -40,6 +41,8 @@ regression, 3 for survival, and 10 for probability.}
 sampling with replacement and 0.632 for sampling without replacement.}
 
 \item{num.threads}{Number of threads to use.}
+
+\item{verbose}{If TRUE, display additional output during execution.}
 
 \item{...}{Any additional arguments, not currently used.}
 }

--- a/man/SL.speedlm.Rd
+++ b/man/SL.speedlm.Rd
@@ -20,7 +20,7 @@ SL.speedlm(Y, X, newX, family, obsWeights, ...)
 \item{...}{Any remaining arguments, not used.}
 }
 \description{
-Speedglm is a fast version of lm()
+Speedlm is a fast version of lm()
 }
 \references{
 Enea, M. A. R. C. O. (2013). Fitting linear models and generalized linear

--- a/man/predict.SL.ranger.Rd
+++ b/man/predict.SL.ranger.Rd
@@ -5,7 +5,7 @@
 \title{Prediction wrapper for ranger random forests}
 \usage{
 \method{predict}{SL.ranger}(object, newdata, family, num.threads = 1,
-  verbose = F, ...)
+  verbose = object$verbose, ...)
 }
 \arguments{
 \item{object}{SL.kernlab object}


### PR DESCRIPTION
Hi,

Quick tweak to SL.ranger to support changing verbosity - which can be very handy for large datasets as it outputs a progress report.

Also includes a minor typo fix in speedlm.Rd that should have been included in the previous PR.

Thanks,
Chris