### PR TITLE
SL.lm: for binomial family bound predictions to [0, 1]

### DIFF
--- a/R/SL.lm.R
+++ b/R/SL.lm.R
@@ -30,7 +30,12 @@ SL.lm <- function(Y, X, newX, family, obsWeights,
 
   pred <- predict(fit, newdata = newX, type = "response")
 
-  fit <- list(object = fit)
+  # For binomial family restrict predicted probability to [0, 1].
+  if (family$family == "binomial") {
+    pred = pmin(pmax(pred, 0), 1)
+  }
+
+  fit <- list(object = fit, family = family)
   class(fit) <- "SL.lm"
 
   out <- list(pred = pred, fit = fit)
@@ -57,6 +62,11 @@ predict.SL.lm <- function(object, newdata, ...) {
   }
 
   pred <- predict(object = object$object, newdata = newdata, type = "response")
+
+  # For binomial family restrict predicted probability to [0, 1].
+  if (object$family$family == "binomial") {
+    pred = pmin(pmax(pred, 0), 1)
+  }
 
   pred
 }

--- a/tests/testthat/test-lm.R
+++ b/tests/testthat/test-lm.R
@@ -43,10 +43,10 @@ print(summary(model$fit$object))
 # Gaussian version.
 sl = SuperLearner(Y_gaus, X, family = gaussian(),
                   SL.library = c("SL.mean", "SL.lm"))
-sl
+print(sl)
 
 pred = predict(sl, X)
-summary(pred$pred)
+print(summary(pred$pred))
 
 # Confirm prediction on matrix version of X.
 pred2 = predict(sl, X_mat)
@@ -56,10 +56,11 @@ expect_equal(pred$pred, pred2$pred)
 # Binomial version.
 sl = SuperLearner(Y_bin, X, family = binomial(),
                   SL.library = c("SL.mean", "SL.lm"))
-sl
+print(sl)
 
 pred = predict(sl, X)
-summary(pred$pred)
+# These predictions should be in [0, 1].
+print(summary(pred$pred))
 
 # Confirm prediction on matrix version of X
 pred2 = predict(sl, X_mat)


### PR DESCRIPTION
Hi,

This is a quick update to the SL.lm wrapper so that binomial family predictions are restricted to [0, 1].

Thanks,
Chris