### PR TITLE
Install sva and genefilter from bioc for appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ build_script:
   - git config --global user.name "travis"
   - git config --global user.email "travis@example.org"
   - Rscript -e "install.packages('xgboost', repos=c('http://dmlc.ml/drat/', 'https://cran.cnr.berkeley.edu/'), type='source')"
-  - Rscript -e "source('http://bioconductor.org/biocLite.R')"
+  - Rscript -e "source('http://bioconductor.org/biocLite.R'); biocLite(c('sva', 'genefilter'))"
   - travis-tool.sh install_deps
   - travis-tool.sh github_package jimhester/covr
 


### PR DESCRIPTION
Hello,

This is a quick patch to install sva and genefilter from bioconductor for appveyor testing. This will remove a devtools::check() note that those packages aren't available for checking. This will also help out for when we eventually add tests that use those packages.

Thanks,
Chris