### PR TITLE
Reverse dependency checking for CI, if SL_CRAN=true

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -8,8 +8,10 @@
 ^\.travis\.yml$
 ^appveyor\.yml$
 ^codecov\.yml$
+^revdep$
+^Makefile$
 
 # Files from building the Guide-to-SuperLearner.rmd vignette.
 ^SuperLearner.png$
-^vignettes/[^/]*_cache
-xgboost.model
+^vignettes/[^/]*_cache$
+^xgboost.model$

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,9 @@
 
 # macOS files
 .DS_Store
+
+xgboost.model
+
+# R reverse dependency testing.
+revdep
+revdep.Rout

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,6 @@ compiler:
 
 env:
   global:
-    - CRAN="http://cran.rstudio.com"
     #- R_BUILD_ARGS="--no-build-vignettes --no-manual"
     - R_CHECK_TIME="TRUE"
     - R_CHECK_TESTS="TRUE"
@@ -48,9 +47,27 @@ env:
     # No error if suggested packages are not available.
     #- _R_CHECK_FORCE_SUGGESTS_=0
 
+cran: "http://cran.rstudio.com"
 warnings_are_errors: true
 #r_check_args: "--no-build-vignettes --no-manual --as-cran --timings"
 r_check_args: "--as-cran --timings"
+r_build_args:
+
+# Override default Travis build process so that we can add conditional
+# reverse dependency checking.
+# Build and check lines based on travis docs:
+# https://docs.travis-ci.com/user/languages/r/#Customizing-the-Travis-build-steps
+script:
+  # Install callr manually since CRAN version is old and this may help
+  # tests/cran/revdep.R to work correctly.
+  # Installing using r_github_packages doesn't seem to work right.
+  - Rscript -e 'source("https://install-github.me/r-lib/callr")'
+  - R CMD build . #--no-build-vignettes --no-manual
+  - R CMD check *tar.gz --as-cran --timings
+  - if [ "${SL_CRAN}" == "true" ]; then
+      Rscript --verbose tests/cran/revdep.R;
+    fi
+
 
 r_packages:
 # Install survival directly, to get the latest version and avoid
@@ -59,7 +76,9 @@ r_packages:
 
 r_github_packages:
   - jimhester/covr
- #- jimhester/lintr
+  # Use custom devtools that shows more info during revdep_check()
+  - ck37/devtools
+  #- jimhester/lintr
 
 bioc_packages:
   - sva
@@ -68,5 +87,6 @@ bioc_packages:
 after_success:
   - Rscript -e 'covr::codecov()'
 
-after_failure:
-  - ./travis-tool.sh dump_logs
+#after_failure:
+  # This doesn't do anything because travis-tool.sh is no longer used.
+  # - ./travis-tool.sh dump_logs

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,6 +22,7 @@ Suggests:
     caret,
     class,
     dbarts,
+    devtools,
     e1071,
     earth,
     gam,

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+# Run CRAN-specific tests.
+cran:
+  # Set environmental variable before running.
+	SL_CRAN=true Rscript tests/cran/revdep.R
+
+clean:
+	rm -rf revdep revdep.Rout

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![CRAN_Status_Badge](http://www.r-pkg.org/badges/version/SuperLearner)](http://cran.r-project.org/web/packages/SuperLearner)
 [![Downloads](http://cranlogs.r-pkg.org/badges/SuperLearner)](http://cran.rstudio.com/package=SuperLearner)
 [![Build Status: travis-ci](https://travis-ci.org/ecpolley/SuperLearner.svg?branch=master)](https://travis-ci.org/ecpolley/SuperLearner)
-[![Build Status: appveyor](https://ci.appveyor.com/api/projects/status/github/ecpolley/SuperLearner?branch=master&svg=true)](https://ci.appveyor.com/project/ecpolley/superlearner)
+[![Build Status: appveyor](https://ci.appveyor.com/api/projects/status/github/ecpolley/SuperLearner?branch=master&svg=true)](https://ci.appveyor.com/project/ecpolley/SuperLearner/history)
 [![codecov](https://codecov.io/gh/ecpolley/SuperLearner/branch/master/graph/badge.svg)](https://codecov.io/gh/ecpolley/SuperLearner)
 
 This is the current version of the SuperLearner R package (version 2.*).

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,4 @@
+# Docs: https://www.appveyor.com/docs/build-configuration/
 # DO NOT CHANGE the "init" and "install" sections below
 
 # Download script file from GitHub
@@ -6,16 +7,24 @@ init:
         $ErrorActionPreference = "Stop"
         Invoke-WebRequest http://raw.github.com/krlmlr/r-appveyor/master/scripts/appveyor-tool.ps1 -OutFile "..\appveyor-tool.ps1"
         Import-Module '..\appveyor-tool.ps1'
+
 install:
   ps: Bootstrap
 
 # Adapt as necessary starting from here
 
+before_build:
+  # Avoid note about non-standard file/directory during R CMD check.
+  - bash -c "echo '^travis-tool\.sh\.cmd$' >> .Rbuildignore"
+
 build_script:
   - git config --global user.name "travis"
   - git config --global user.email "travis@example.org"
   - Rscript -e "install.packages('xgboost', repos=c('http://dmlc.ml/drat/', 'https://cran.cnr.berkeley.edu/'), type='source')"
-  - Rscript -e "source('http://bioconductor.org/biocLite.R'); biocLite(c('sva', 'genefilter'))"
+  #- travis-tool.sh install_bioc BiocInstaller
+  - Rscript -e "source('https://bioconductor.org/biocLite.R'); biocLite()"
+  #- travis-tool.sh install_bioc sva genefilter
+  - travis-tool.sh install_bioc_deps
   - travis-tool.sh install_deps
   - travis-tool.sh github_package jimhester/covr
 
@@ -38,6 +47,8 @@ environment:
 
   matrix:
     - R_VERSION: release
+    - R_VERSION: devel
+    - R_VERSION: oldrel
 
 artifacts:
   - path: '*.Rcheck\**\*.log'

--- a/tests/cran/revdep.R
+++ b/tests/cran/revdep.R
@@ -1,0 +1,71 @@
+#!/usr/bin/Rscript
+# ^ support Rscript execution
+
+# This file is intended to be run prior to a release, not during
+# normal unit testing.
+# To run CI on Travis set env variable SL_CRAN=1 in the web UI,
+# then re-build commit.
+
+# Based on https://github.com/HenrikBengtsson/future/tree/master/revdep
+# And https://github.com/travis-ci/travis-build/blob/master/lib/travis/build/script/r.rb#L256
+library(devtools)
+
+# Run manually or if SL_CRAN environmental variable is set and we're not in a
+# pull request build.
+# This would be done as prep for a CRAN release.
+# This is not currently working on our CI systems: Travis and Appveyor.
+if (Sys.getenv("SL_CRAN") == "true" &&
+    Sys.getenv("TRAVIS_PULL_REQUEST") %in% c("", "false") &&
+    Sys.getenv("APPVEYOR_PULL_REQUEST_NUMBER") == "") {
+
+  cat("Checking reverse dependencies.\n")
+
+  if (!requireNamespace("BiocInstaller", quietly = T)) {
+    # Manually re-install bioc, unclear why this is necessary on Appveyor.
+    source('https://bioconductor.org/biocLite.R')
+    # This will install BiocInstaller.
+    biocLite()
+  }
+
+  print(sessionInfo())
+
+  # Clear any existing results.
+  devtools::revdep_check_reset()
+
+  ignore_packages = NULL
+
+  # Customize reverse dependency checking for Travis.
+  if (Sys.getenv("TRAVIS") == "true") {
+
+    # This should be /home/travis/R/library on Travis.
+    cat("Using R library:", Sys.getenv("R_LIBS_USER"), "\n")
+
+    # Set revdep.libpath to reuse packages we already installed.
+    # Without this option revdev_check() fails and it takes forever.
+    options(devtools.revdep.libpath = Sys.getenv("R_LIBS_USER"))
+  }
+
+  result = devtools::revdep_check(bioconductor = T, recursive = F,
+                                  ignore = ignore_packages,
+                                  #threads = RhpcBLASctl::get_num_cores(),
+                                  threads = 1,
+                                  # Set to F for debugging.
+                                  quiet_check = F)
+
+  if (length(result) > 0) {
+    # Save results to the revdep main directory.
+    devtools::revdep_check_save_summary()
+
+    # Print any problems.
+    print(devtools::revdep_check_print_problems())
+
+    # If this script is running inside travis CI, explicitly quit.
+    if (Sys.getenv("TRAVIS_R_VERSION") != "") {
+      q(status = 1, save = "no");
+    }
+  } else {
+    cat("No reverse dependency problems found. Great job!\n")
+  }
+} else {
+  cat("Skipping revdep.\n")
+}


### PR DESCRIPTION
Here is some initial work to integrate reverse dependency testing into the CI system per #84 . It is set to run if an environmental variable SL_CRAN is set in Travis or Appveyor, so typically that would be done after a commit and the commit would then be rebuilt.

Unfortunately I haven't been able to get it working on Appveyor and Travis has been broken all day, but the test file can be run on a local computer just fine to help with CRAN releases (and everything passes). It may require a lot more digging into the CI build systems & revdep code, and I haven't found any other packages that do it. Right now it's erroring during revdep testing while trying to install SuperLearner: https://ci.appveyor.com/project/ck37/superlearner/build/1.0.167/job/66k87xxb0a8sor37#L525

The issue may stem from running revdep within a testthat call (within devtools::check) for the package. Another approach would be to have a revdep check run after the normal package testing, which is what I initially tried but couldn't figure out how to get it close to working.