### PR TITLE
Allow passing of single 'split' index to SampleSplitSuperLearner()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: SuperLearner
 Type: Package
 Title: Super Learner Prediction
-Version: 2.0-24-9000
-Date: 2017-11-06
+Version: 2.0-23-9000
+Date: 2017-11-07
 Authors@R: c(person("Eric", "Polley", email = "polley.eric@mayo.edu", role = c("aut", "cre")), person("Erin", "LeDell", role = c("aut")), person("Chris", "Kennedy", role = c("aut")), person("Sam", "Lendle", role = c("ctb")), person("Mark", "van der Laan", role = c("aut", "ths")))
 Maintainer: Eric Polley <polley.eric@mayo.edu>
 Description: Implements the super learner prediction method and contains a

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: SuperLearner
 Type: Package
 Title: Super Learner Prediction
-Version: 2.0-23-9000
-Date: 2017-07-20
+Version: 2.0-24-9000
+Date: 2017-11-06
 Authors@R: c(person("Eric", "Polley", email = "polley.eric@mayo.edu", role = c("aut", "cre")), person("Erin", "LeDell", role = c("aut")), person("Chris", "Kennedy", role = c("aut")), person("Sam", "Lendle", role = c("ctb")), person("Mark", "van der Laan", role = c("aut", "ths")))
 Maintainer: Eric Polley <polley.eric@mayo.edu>
 Description: Implements the super learner prediction method and contains a

--- a/R/SampleSplitSuperLearner.R
+++ b/R/SampleSplitSuperLearner.R
@@ -37,12 +37,22 @@ SampleSplitSuperLearner <- function(Y, X, newX = NULL, family = gaussian(), SL.l
   kScreen <- length(library$screenAlgorithm)
   Z <- matrix(NA, N, k)
   libraryNames <- paste(library$library$predAlgorithm, library$screenAlgorithm[library$library$rowScreen], sep="_")
-	
+
+	is.wholenumber <- function(x, tol = .Machine$double.eps^0.5)  abs(x - round(x)) < tol
 	# split data
 	# todo: allow user to supply these, in a cvControl like argument
 	# split should be either a single value between 0 and 1, OR a vector with the validRows
 	if(length(split) == 1) {
-		if(split <= 0 | split >= 1) stop("invalid split value, must be between 0 and 1")
+		if(split <= 0) {
+			stop("invalid split value, must be between 0 and 1")
+		} else if(split >= 1) {
+			if((split <= N)&is.wholenumber(split)) {
+				validRows <- split
+				trainRows <- setdiff(seq(N), validRows)
+			} else {
+				stop("invalid split value, must be between 0 and 1")
+			}
+		}
 		validRows <- sample.int(N, size = round((1 - split)*N))
 		trainRows <- setdiff(seq(N), validRows)
 	} else {

--- a/R/SampleSplitSuperLearner.R
+++ b/R/SampleSplitSuperLearner.R
@@ -52,9 +52,10 @@ SampleSplitSuperLearner <- function(Y, X, newX = NULL, family = gaussian(), SL.l
 			} else {
 				stop("invalid split value, must be between 0 and 1")
 			}
+		} else {
+			validRows <- sample.int(N, size = round((1 - split)*N))
+			trainRows <- setdiff(seq(N), validRows)
 		}
-		validRows <- sample.int(N, size = round((1 - split)*N))
-		trainRows <- setdiff(seq(N), validRows)
 	} else {
 		if(length(split) >= N) stop("split should be a vector with the row numbers for the samples in the validation split")
 		validRows <- split

--- a/R/SampleSplitSuperLearner.R
+++ b/R/SampleSplitSuperLearner.R
@@ -38,29 +38,41 @@ SampleSplitSuperLearner <- function(Y, X, newX = NULL, family = gaussian(), SL.l
   Z <- matrix(NA, N, k)
   libraryNames <- paste(library$library$predAlgorithm, library$screenAlgorithm[library$library$rowScreen], sep="_")
 
-	is.wholenumber <- function(x, tol = .Machine$double.eps^0.5)  abs(x - round(x)) < tol
-	# split data
-	# todo: allow user to supply these, in a cvControl like argument
-	# split should be either a single value between 0 and 1, OR a vector with the validRows
-	if(length(split) == 1) {
-		if(split <= 0) {
-			stop("invalid split value, must be between 0 and 1")
-		} else if(split >= 1) {
-			if((split <= N)&is.wholenumber(split)) {
-				validRows <- split
-				trainRows <- setdiff(seq(N), validRows)
-			} else {
-				stop("invalid split value, must be between 0 and 1")
-			}
-		} else {
-			validRows <- sample.int(N, size = round((1 - split)*N))
-			trainRows <- setdiff(seq(N), validRows)
-		}
-	} else {
-		if(length(split) >= N) stop("split should be a vector with the row numbers for the samples in the validation split")
-		validRows <- split
-		trainRows <- setdiff(seq(N), validRows)
-	}
+  # split data
+  # todo: allow user to supply these, in a cvControl like argument
+  # split should be either a single value between 0 and 1, OR a vector with the validRows
+  # is.wholenumber() borrowed from ?is.integer()
+  is.wholenumber <- function(x, tol = .Machine$double.eps^0.5)  abs(x - round(x)) < tol
+  treatSplitAsIndices <- function(x) {
+    res <- FALSE
+    if(length(x) == 1) {
+      if((x >= 1) & (x <= N) & is.wholenumber(x)) {
+        res <- TRUE
+      }
+    } else if((length(x) > 1) & (length(x) < N)) {
+      res <- TRUE
+    }
+    return(res)
+  }
+  treatSplitAsFraction <- function(x) {
+    res <- FALSE
+    if(length(x) == 1) {
+      if((x > 0) & (x < 1)) {
+        res <- TRUE
+      }
+    }
+    return(res)
+  }
+
+  validRows <- if(treatSplitAsIndices(split)) {
+    split
+  } else if(treatSplitAsFraction(split)) {
+    sample.int(N, size = round((1 - split)*N))
+  } else {
+    stop("split should be a single value between 0 and 1 (not inclusive) OR\n",
+         "a numeric vector containing row numbers of X in the validation sample.")
+  }
+  trainRows <- setdiff(seq(N), validRows)
 	
 	# put fitLibrary in it's own environment to locate later
 	fitLibEnv <- new.env()

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -2,8 +2,9 @@
 
 ---
 Version: 2.0-23
-Date: 2017-09-26
+Date: 2017-11-07
 * fixed transformation of outcome in SL.dbarts for binomial family
+* SampleSplitSuperLearner(): support validation sample size of 1 when observation's row number is passed in via 'split'.
 
 ---
 Version: 2.0-22

--- a/tests/testthat/test-SampleSplitSuperLearner.R
+++ b/tests/testthat/test-SampleSplitSuperLearner.R
@@ -1,0 +1,37 @@
+########################
+# Simulate data
+set.seed(23432)
+# Create small training set for quick tests.
+n <- 80
+p <- 6
+X <- data.frame(matrix(rnorm(n * p), nrow = n, ncol = p))
+colnames(X) <- paste0("X", 1:p)
+gen_y = function(x) x[, 1] + sqrt(abs(x[, 2] * x[, 3])) + x[, 2] - x[, 3] + rnorm(nrow(x))
+Y <- gen_y(X)
+
+########################
+# Run the SampleSplitSuperLearner
+SL.library = c("SL.randomForest", "SL.glmnet", "SL.glm", "SL.mean")
+
+# default split: 80% in training, 20% in validation
+defaultSplit = formals(SampleSplitSuperLearner)$split
+sssl1 = SampleSplitSuperLearner(Y = Y, X = X, SL.library = SL.library)
+expect_equal(length(sssl1$validRows), (1 - defaultSplit) * n)
+expect_false(any(sssl1$errorsInLibrary))
+expect_false(any(sssl1$errorsInCVLibrary))
+
+# split by specifying row numbers in validation set
+validRows = seq(from = round(n/5), to = n, by = round(n/10))
+sssl2 = SampleSplitSuperLearner(Y = Y, X = X, SL.library = SL.library,
+								split = validRows)
+expect_equal(sssl2$validRows, validRows)
+expect_false(any(sssl2$errorsInLibrary))
+expect_false(any(sssl2$errorsInCVLibrary))
+
+# split with only one observation in validation set
+validRows = 1
+sssl3 = SampleSplitSuperLearner(Y = Y, X = X, SL.library = SL.library,
+								split = validRows)
+expect_equal(sssl3$validRows, validRows)
+expect_false(any(sssl3$errorsInLibrary))
+expect_false(any(sssl3$errorsInCVLibrary))


### PR DESCRIPTION
I'm doing something akin to leave-one-out CV, but with observation-specific weights and columns of X. I'm currently using this fork's version of `SampleSplitSuperLearner()` to accomplish this by specifying a single row of X as the validation sample. All other solutions that I've come up with thus far either require unnecessary additional sample splitting (for example, passing in the validation observation via `newX`) or unnecessary duplication of code (for example, writing a custom `GridLearner()`, like a `SuperLearner()` that doesn't cross-validate).

Previously, `SampleSplitSuperLearner()` needed at least two observations to be in the validation set if specific row numbers of X were provided. I modified `SampleSplitSuperLearner()` to accept only one specific observation as the validation sample, while still maintaining the ability to pass in a proportion of the sample to use as the training set instead of row numbers. Let me know if you foresee any issues with this modification.