### PR TITLE
SuperLearner() and friends now tolerate single-column X

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: SuperLearner
 Type: Package
 Title: Super Learner Prediction
 Version: 2.0-23-9000
-Date: 2017-11-07
+Date: 2017-11-29
 Authors@R: c(person("Eric", "Polley", email = "polley.eric@mayo.edu", role = c("aut", "cre")), person("Erin", "LeDell", role = c("aut")), person("Chris", "Kennedy", role = c("aut")), person("Sam", "Lendle", role = c("ctb")), person("Mark", "van der Laan", role = c("aut", "ths")))
 Maintainer: Eric Polley <polley.eric@mayo.edu>
 Description: Implements the super learner prediction method and contains a

--- a/R/SampleSplitSuperLearner.R
+++ b/R/SampleSplitSuperLearner.R
@@ -1,281 +1,281 @@
 #  SuperLearner for Sample Split instead of V-fold CV
-#  
+#
 #  Created by Eric Polley on 2014-04-15.
-# 
+#
 SampleSplitSuperLearner <- function(Y, X, newX = NULL, family = gaussian(), SL.library, method = 'method.NNLS', id = NULL, verbose = FALSE, control = list(), split = 0.8, obsWeights = NULL) {
-  if(is.character(method)) {
-    if(exists(method, mode = 'list')) {
-      method <- get(method, mode = 'list')
-    } else if(exists(method, mode = 'function')) {
-      method <- get(method, mode = 'function')()
+    if(is.character(method)) {
+        if(exists(method, mode = 'list')) {
+            method <- get(method, mode = 'list')
+        } else if(exists(method, mode = 'function')) {
+            method <- get(method, mode = 'function')()
+        }
+    } else if(is.function(method)) {
+        method <- method()
     }
-  } else if(is.function(method)) {
-    method <- method()
-  }
-  if(!is.list(method)) {
-    stop("method is not in the appropriate format. Check out help('method.template')")
-  }
-  if(!is.null(method$require)) {
-	  sapply(method$require, function(x) require(force(x), character.only = TRUE))
-	}
-  # get defaults for controls and make sure in correct format
-  control <- do.call('SuperLearner.control', control)
-  
-  # put together the library
-  # should this be in a new environment?
-  library <- .createLibrary(SL.library)
-	.check.SL.library(library = c(unique(library$library$predAlgorithm), library$screenAlgorithm))
-	
-	call <- match.call(expand.dots = TRUE)
-  # should we be checking X and newX for data.frame?
-  # data.frame not required, but most of the built-in wrappers assume a data.frame
-  if(!inherits(X, 'data.frame')) message('X is not a data frame. Check the algorithms in SL.library to make sure they are compatible with non data.frame inputs')
-  varNames <- colnames(X)
-  N <- dim(X)[1L]
-  p <- dim(X)[2L]
-  k <- nrow(library$library)
-  kScreen <- length(library$screenAlgorithm)
-  Z <- matrix(NA, N, k)
-  libraryNames <- paste(library$library$predAlgorithm, library$screenAlgorithm[library$library$rowScreen], sep="_")
-
-  # split data
-  # todo: allow user to supply these, in a cvControl like argument
-  # split should be either a single value between 0 and 1, OR a vector with the validRows
-  # is.wholenumber() borrowed from ?is.integer()
-  is.wholenumber <- function(x, tol = .Machine$double.eps^0.5)  abs(x - round(x)) < tol
-  treatSplitAsIndices <- function(x) {
-    res <- FALSE
-    if(length(x) == 1) {
-      if((x >= 1) & (x <= N) & is.wholenumber(x)) {
-        res <- TRUE
-      }
-    } else if((length(x) > 1) & (length(x) < N)) {
-      res <- TRUE
+    if(!is.list(method)) {
+        stop("method is not in the appropriate format. Check out help('method.template')")
     }
-    return(res)
-  }
-  treatSplitAsFraction <- function(x) {
-    res <- FALSE
-    if(length(x) == 1) {
-      if((x > 0) & (x < 1)) {
-        res <- TRUE
-      }
+    if(!is.null(method$require)) {
+        sapply(method$require, function(x) require(force(x), character.only = TRUE))
     }
-    return(res)
-  }
+    # get defaults for controls and make sure in correct format
+    control <- do.call('SuperLearner.control', control)
 
-  validRows <- if(treatSplitAsIndices(split)) {
-    split
-  } else if(treatSplitAsFraction(split)) {
-    sample.int(N, size = round((1 - split)*N))
-  } else {
-    stop("split should be a single value between 0 and 1 (not inclusive) OR\n",
-         "a numeric vector containing row numbers of X in the validation sample.")
-  }
-  trainRows <- setdiff(seq(N), validRows)
-	
-	# put fitLibrary in it's own environment to locate later
-	fitLibEnv <- new.env()
-	assign('fitLibrary', vector('list', length = k), envir = fitLibEnv)
-	assign('libraryNames', libraryNames, envir = fitLibEnv)
-	evalq(names(fitLibrary) <- libraryNames, envir = fitLibEnv)
-	
-  # errors* records if an algorithm stops either in the CV step and/or in full data
-	errorsInCVLibrary <- rep(0, k)
-	errorsInLibrary <- rep(0, k)
-	
-  # if newX is missing, use X
-	if(is.null(newX)) {
-		newX <- X
-	}
-  # Are these checks still required?
-	if(!identical(colnames(X), colnames(newX))) {
-		stop("The variable names and order in newX must be identical to the variable names and order in X")
-	}
-	if (sum(is.na(X)) > 0 | sum(is.na(newX)) > 0 | sum(is.na(Y)) > 0) {
-		stop("missing data is currently not supported. Check Y, X, and newX for missing values")
-	}
-	if (!is.numeric(Y)) {
-		stop("the outcome Y must be a numeric vector")
-	}
-  # family can be either character or function, so these lines put everything together (code from glm())
-	if(is.character(family))
-		family <- get(family, mode="function", envir=parent.frame())
-	if(is.function(family))
-		family <- family()
-	if (is.null(family$family)) {
-		print(family)
-		stop("'family' not recognized")
-	}
-	
-	if (family$family != "binomial" & isTRUE("cvAUC" %in% method$require)){
-		stop("'method.AUC' is designed for the 'binomial' family only")
-	}
-	
-  # test id
-	if(is.null(id)) {
-		id <- seq(N)
-	}
-	if(!identical(length(id), N)) {
-		stop("id vector must have the same dimension as Y")
-	}
-  # test observation weights
-	if(is.null(obsWeights)) {
-		obsWeights <- rep(1, N)
-	}
-	if(!identical(length(obsWeights), N)) {
-		stop("obsWeights vector must have the same dimension as Y")
-	}
-	
-  # create datasets for the prediction algorithms
-	# Do we need to make a copy of the data here?
-	tempLearn <- X[trainRows, , drop = FALSE]
-	tempOutcome <- Y[trainRows]
-	tempValid <- X[validRows, , drop = FALSE]
-	tempValidOutcome <- Y[validRows]
-	tempWhichScreen <- matrix(NA, nrow = kScreen, ncol = p)
-	tempId <- id[trainRows]
-	tempObsWeights <- obsWeights[trainRows]
-	  
-    # should this be converted to a lapply also?
-	for(s in seq(kScreen)) {
-		testScreen <- try(do.call(library$screenAlgorithm[s], list(Y = tempOutcome, X = tempLearn, family = family, id = tempId, obsWeights = tempObsWeights)))
-		if(inherits(testScreen, "try-error")) {
-			warning(paste("replacing failed screening algorithm,", library$screenAlgorithm[s], ", with All()", "\n ")) 
-			tempWhichScreen[s, ] <- TRUE
-		} else {
-			tempWhichScreen[s, ] <- testScreen
-		}
-		if(verbose) {
-			message(paste("Number of covariates in ", library$screenAlgorithm[s], " is: ", sum(tempWhichScreen[s, ]), sep = ""))
-		}
-	} #end screen
-		
-    
-    Z <- matrix(NA, nrow = nrow(tempValid), ncol = k) # k is the number of algorithms in the library
-		# should we replace the subset() call below?
-		for(s in seq(k)) {
-		  testAlg <- try({
-		    select <- tempWhichScreen[library$library$rowScreen[s], ]
-		    if (all(select)) {
-		      tempX <- tempLearn
-		      tempnewX <- tempValid
-		    } else {
-		      tempX <- subset(tempLearn, select = which(select), drop=FALSE)
-		      tempnewX <- subset(tempValid, select = which(select), drop=FALSE)
-		    }
-		    do.call(library$library$predAlgorithm[s], list(
-		      Y = tempOutcome,
-		      X = tempX,
-		      newX = tempnewX,
-		      family = family, id = tempId, obsWeights = tempObsWeights))
-		  })
-			if(inherits(testAlg, "try-error")) {
-				warning(paste("Error in algorithm", library$library$predAlgorithm[s], "\n  The Algorithm will be removed from the Super Learner (i.e. given weight 0) \n" )) 
-        # errorsInCVLibrary[s] <<- 1
-			} else {
-				Z[, s] <- testAlg$pred
-			}
-			if(verbose) message(paste("CV", libraryNames[s]))
-		} #end library
+    # put together the library
+    # should this be in a new environment?
+    library <- .createLibrary(SL.library)
+    .check.SL.library(library = c(unique(library$library$predAlgorithm), library$screenAlgorithm))
 
-	# row order in Z should match row order in tempValid and tempValidOutcome
-	# Z[unlist(validRows, use.names = FALSE), ] <- do.call('rbind', lapply(validRows, FUN = .crossValFUN, Y = Y, dataX = X, id = id, obsWeights = obsWeights, library = library, kScreen = kScreen, k = k, p = p, libraryNames = libraryNames))
-	
-# check for errors. If any algorithms had errors, replace entire column with 0 even if error is only in one fold.
+    call <- match.call(expand.dots = TRUE)
+    # should we be checking X and newX for data.frame?
+    # data.frame not required, but most of the built-in wrappers assume a data.frame
+    if(!inherits(X, 'data.frame')) message('X is not a data frame. Check the algorithms in SL.library to make sure they are compatible with non data.frame inputs')
+    varNames <- colnames(X)
+    N <- dim(X)[1L]
+    p <- dim(X)[2L]
+    k <- nrow(library$library)
+    kScreen <- length(library$screenAlgorithm)
+    Z <- matrix(NA, N, k)
+    libraryNames <- paste(library$library$predAlgorithm, library$screenAlgorithm[library$library$rowScreen], sep="_")
 
-  errorsInCVLibrary <- apply(Z, 2, function(x) any(is.na(x)))
-  if(sum(errorsInCVLibrary) > 0) {
-		Z[, as.logical(errorsInCVLibrary)] <- 0 
-	}
-	if(all(Z == 0)) {
-		stop("All algorithms dropped from library")
-	}
-	
-  # compute weights for each algorithm in library:
-  getCoef <- method$computeCoef(Z = Z, Y = tempValidOutcome, libraryNames = libraryNames, obsWeights = obsWeights[validRows], control = control, verbose = verbose)
-  coef <- getCoef$coef
-  names(coef) <- libraryNames
+    # split data
+    # todo: allow user to supply these, in a cvControl like argument
+    # split should be either a single value between 0 and 1, OR a vector with the validRows
+    # is.wholenumber() borrowed from ?is.integer()
+    is.wholenumber <- function(x, tol = .Machine$double.eps^0.5)  abs(x - round(x)) < tol
+    treatSplitAsIndices <- function(x) {
+        res <- FALSE
+        if(length(x) == 1) {
+            if((x >= 1) & (x <= N) & is.wholenumber(x)) {
+                res <- TRUE
+            }
+        } else if((length(x) > 1) & (length(x) < N)) {
+          res <- TRUE
+        }
+        return(res)
+    }
+    treatSplitAsFraction <- function(x) {
+        res <- FALSE
+        if(length(x) == 1) {
+            if((x > 0) & (x < 1)) {
+                res <- TRUE
+            }
+        }
+        return(res)
+    }
 
-  # now fit all algorithms in library on entire learning data set and predict on newX
-  m <- dim(newX)[1L]
-  predY <- matrix(NA, nrow = m, ncol = k)
-  # whichScreen <- matrix(NA, nrow = kScreen, ncol = p)
-  
-  .screenFun <- function(fun, list) {
-    testScreen <- try(do.call(fun, list))
-    if(inherits(testScreen, "try-error")) {
-  		warning(paste("replacing failed screening algorithm,", fun, ", with All() in full data", "\n ")) 
-  		out <- rep(TRUE, ncol(list$X))
-  	} else {
-  		out <- testScreen
-  	}
-    return(out)
-  }
-  whichScreen <- t(sapply(library$screenAlgorithm, FUN = .screenFun, list = list(Y = Y, X = X, family = family, id = id, obsWeights = obsWeights)))
-	
-  .predFun <- function(index, lib, Y, dataX, newX, whichScreen, family, id, obsWeights, verbose, control, libraryNames) {
-    testAlg <- try({
-      select <- whichScreen[lib$rowScreen[index], ]
-      if (all(select)) {
-        tempX <- dataX
-        tempnewX <- newX
-      } else {
-        tempX <- subset(dataX, select = which(select), drop=FALSE)
-        tempnewX <- subset(newX, select = which(select), drop=FALSE)
-      }
-      do.call(lib$predAlgorithm[index], list(
-        Y = Y,
-        X = tempX,
-        newX = tempnewX,
-        family = family, id = id, obsWeights = obsWeights))
-    })
-    # testAlg <- try(do.call(lib$predAlgorithm[index], list(Y = Y, X = dataX[, whichScreen[lib$rowScreen[index], drop = FALSE]], newX = newX[, whichScreen[lib$rowScreen[index], drop = FALSE]], family = family, id = id, obsWeights = obsWeights)))
-    if(inherits(testAlg, "try-error")) {
-      warning(paste("Error in algorithm", lib$predAlgorithm[index], " on full data", "\n  The Algorithm will be removed from the Super Learner (i.e. given weight 0) \n" )) 
-      out <- rep.int(NA, times = nrow(newX))
+    validRows <- if(treatSplitAsIndices(split)) {
+        split
+    } else if(treatSplitAsFraction(split)) {
+        sample.int(N, size = round((1 - split)*N))
     } else {
-      out <- testAlg$pred
-      if(control$saveFitLibrary) {
-        eval(bquote(fitLibrary[[.(index)]] <- .(testAlg$fit)), envir = fitLibEnv)
-      }
+        stop("split should be a single value between 0 and 1 (not inclusive) OR\n",
+           "a numeric vector containing row numbers of X in the validation sample.")
     }
-    if(verbose) {
-      message(paste("full", libraryNames[index]))
+    trainRows <- setdiff(seq(N), validRows)
+
+    # put fitLibrary in it's own environment to locate later
+    fitLibEnv <- new.env()
+    assign('fitLibrary', vector('list', length = k), envir = fitLibEnv)
+    assign('libraryNames', libraryNames, envir = fitLibEnv)
+    evalq(names(fitLibrary) <- libraryNames, envir = fitLibEnv)
+
+    # errors* records if an algorithm stops either in the CV step and/or in full data
+    errorsInCVLibrary <- rep(0, k)
+    errorsInLibrary <- rep(0, k)
+
+    # if newX is missing, use X
+    if(is.null(newX)) {
+        newX <- X
     }
-    invisible(out)
-  }
-  predY <- do.call('cbind', lapply(seq(k), FUN = .predFun, lib = library$library, Y = Y, dataX = X, newX = newX, whichScreen = whichScreen, family = family, id = id, obsWeights = obsWeights, verbose = verbose, control = control, libraryNames = libraryNames))
-  
-  # check for errors
-	errorsInLibrary <- apply(predY, 2, function(xx) any(is.na(xx)))
-	if(sum(errorsInLibrary) > 0) {
-		if(sum(coef[as.logical(errorsInLibrary)]) > 0) {
-			warning(paste("re-running estimation of coefficients removing failed algorithm(s) \n Orignial coefficients are: \n", coef, "\n"))
-			Z[, as.logical(errorsInLibrary)] <- 0
-			if(all(Z == 0)) {
-				stop("All algorithms dropped from library")
-			}
-      getCoef <- method$computeCoef(Z = Z, Y = tempValidOutcome, libraryNames = libraryNames, obsWeights = obsWeights[validRows], control = control, verbose = verbose)
-      coef <- getCoef$coef
-      names(coef) <- libraryNames
-		} else {
-			warning("coefficients already 0 for all failed algorithm(s)")
-		}
-	}
-	
-  # compute super learner predictions on newX
-	getPred <- method$computePred(predY = predY, coef = coef, control = control)
-	
-	# add names of algorithms to the predictions
-	colnames(predY) <- libraryNames
-	# clean up when errors in library
-	if(sum(errorsInCVLibrary) > 0) {
-		getCoef$cvRisk[as.logical(errorsInCVLibrary)] <- NA
-	}
-	
-  # put everything together in a list
-  out <- list(call = call, libraryNames = libraryNames, SL.library = library, SL.predict = getPred, coef = coef, library.predict = predY, Z = Z, cvRisk = getCoef$cvRisk, family = family, fitLibrary = get('fitLibrary', envir = fitLibEnv), varNames = varNames, validRows = validRows, method = method, whichScreen = whichScreen, control = control, split = split, errorsInCVLibrary = errorsInCVLibrary, errorsInLibrary = errorsInLibrary)
-	class(out) <- c("SuperLearner")
-	return(out)
+    # Are these checks still required?
+    if(!identical(colnames(X), colnames(newX))) {
+        stop("The variable names and order in newX must be identical to the variable names and order in X")
+    }
+    if (sum(is.na(X)) > 0 | sum(is.na(newX)) > 0 | sum(is.na(Y)) > 0) {
+        stop("missing data is currently not supported. Check Y, X, and newX for missing values")
+    }
+    if (!is.numeric(Y)) {
+        stop("the outcome Y must be a numeric vector")
+    }
+    # family can be either character or function, so these lines put everything together (code from glm())
+    if(is.character(family))
+        family <- get(family, mode="function", envir=parent.frame())
+    if(is.function(family))
+        family <- family()
+    if (is.null(family$family)) {
+        print(family)
+        stop("'family' not recognized")
+    }
+
+    if (family$family != "binomial" & isTRUE("cvAUC" %in% method$require)){
+        stop("'method.AUC' is designed for the 'binomial' family only")
+    }
+
+    # test id
+    if(is.null(id)) {
+        id <- seq(N)
+    }
+    if(!identical(length(id), N)) {
+        stop("id vector must have the same dimension as Y")
+    }
+    # test observation weights
+    if(is.null(obsWeights)) {
+        obsWeights <- rep(1, N)
+    }
+    if(!identical(length(obsWeights), N)) {
+        stop("obsWeights vector must have the same dimension as Y")
+    }
+
+    # create datasets for the prediction algorithms
+    # Do we need to make a copy of the data here?
+    tempLearn <- X[trainRows, , drop = FALSE]
+    tempOutcome <- Y[trainRows]
+    tempValid <- X[validRows, , drop = FALSE]
+    tempValidOutcome <- Y[validRows]
+    tempWhichScreen <- matrix(NA, nrow = kScreen, ncol = p)
+    tempId <- id[trainRows]
+    tempObsWeights <- obsWeights[trainRows]
+
+    # should this be converted to a lapply also?
+    for(s in seq(kScreen)) {
+        testScreen <- try(do.call(library$screenAlgorithm[s], list(Y = tempOutcome, X = tempLearn, family = family, id = tempId, obsWeights = tempObsWeights)))
+        if(inherits(testScreen, "try-error")) {
+            warning(paste("replacing failed screening algorithm,", library$screenAlgorithm[s], ", with All()", "\n ")) 
+            tempWhichScreen[s, ] <- TRUE
+        } else {
+            tempWhichScreen[s, ] <- testScreen
+        }
+        if(verbose) {
+            message(paste("Number of covariates in ", library$screenAlgorithm[s], " is: ", sum(tempWhichScreen[s, ]), sep = ""))
+        }
+    } #end screen
+
+    Z <- matrix(NA, nrow = nrow(tempValid), ncol = k) # k is the number of algorithms in the library
+    # should we replace the subset() call below?
+    for(s in seq(k)) {
+        testAlg <- try({
+            select <- tempWhichScreen[library$library$rowScreen[s], ]
+            if (all(select)) {
+                tempX <- tempLearn
+                tempnewX <- tempValid
+            } else {
+                tempX <- subset(tempLearn, select = which(select), drop=FALSE)
+                tempnewX <- subset(tempValid, select = which(select), drop=FALSE)
+            }
+            do.call(library$library$predAlgorithm[s], list(
+                Y = tempOutcome,
+                X = tempX,
+                newX = tempnewX,
+                family = family, id = tempId, obsWeights = tempObsWeights))
+            })
+            if(inherits(testAlg, "try-error")) {
+                warning(paste("Error in algorithm", library$library$predAlgorithm[s], "\n  The Algorithm will be removed from the Super Learner (i.e. given weight 0) \n" ))
+                # errorsInCVLibrary[s] <<- 1
+        } else {
+            Z[, s] <- testAlg$pred
+        }
+        if(verbose) message(paste("CV", libraryNames[s]))
+    } #end library
+
+    # row order in Z should match row order in tempValid and tempValidOutcome
+    # Z[unlist(validRows, use.names = FALSE), ] <- do.call('rbind', lapply(validRows, FUN = .crossValFUN, Y = Y, dataX = X, id = id, obsWeights = obsWeights, library = library, kScreen = kScreen, k = k, p = p, libraryNames = libraryNames))
+
+    # check for errors. If any algorithms had errors, replace entire column with 0 even if error is only in one fold.
+
+    errorsInCVLibrary <- apply(Z, 2, function(x) any(is.na(x)))
+    if(sum(errorsInCVLibrary) > 0) {
+        Z[, as.logical(errorsInCVLibrary)] <- 0
+    }
+    if(all(Z == 0)) {
+        stop("All algorithms dropped from library")
+    }
+
+    # compute weights for each algorithm in library:
+    getCoef <- method$computeCoef(Z = Z, Y = tempValidOutcome, libraryNames = libraryNames, obsWeights = obsWeights[validRows], control = control, verbose = verbose)
+    coef <- getCoef$coef
+    names(coef) <- libraryNames
+
+    # now fit all algorithms in library on entire learning data set and predict on newX
+    m <- dim(newX)[1L]
+    predY <- matrix(NA, nrow = m, ncol = k)
+    # whichScreen <- matrix(NA, nrow = kScreen, ncol = p)
+
+    .screenFun <- function(fun, list) {
+        testScreen <- try(do.call(fun, list))
+        if(inherits(testScreen, "try-error")) {
+            warning(paste("replacing failed screening algorithm,", fun, ", with All() in full data", "\n "))
+            out <- rep(TRUE, ncol(list$X))
+        } else {
+            out <- testScreen
+        }
+        return(out)
+    }
+    whichScreen <- sapply(library$screenAlgorithm, FUN = .screenFun, list = list(Y = Y, X = X, family = family, id = id, obsWeights = obsWeights), simplify = FALSE)
+    whichScreen <- do.call(rbind, whichScreen)
+
+    .predFun <- function(index, lib, Y, dataX, newX, whichScreen, family, id, obsWeights, verbose, control, libraryNames) {
+        testAlg <- try({
+            select <- whichScreen[lib$rowScreen[index], ]
+            if (all(select)) {
+                tempX <- dataX
+                tempnewX <- newX
+            } else {
+                tempX <- subset(dataX, select = which(select), drop=FALSE)
+                tempnewX <- subset(newX, select = which(select), drop=FALSE)
+            }
+            do.call(lib$predAlgorithm[index], list(
+                Y = Y,
+                X = tempX,
+                newX = tempnewX,
+                family = family, id = id, obsWeights = obsWeights))
+        })
+        # testAlg <- try(do.call(lib$predAlgorithm[index], list(Y = Y, X = dataX[, whichScreen[lib$rowScreen[index], drop = FALSE]], newX = newX[, whichScreen[lib$rowScreen[index], drop = FALSE]], family = family, id = id, obsWeights = obsWeights)))
+        if(inherits(testAlg, "try-error")) {
+            warning(paste("Error in algorithm", lib$predAlgorithm[index], " on full data", "\n  The Algorithm will be removed from the Super Learner (i.e. given weight 0) \n" ))
+            out <- rep.int(NA, times = nrow(newX))
+        } else {
+            out <- testAlg$pred
+            if(control$saveFitLibrary) {
+                eval(bquote(fitLibrary[[.(index)]] <- .(testAlg$fit)), envir = fitLibEnv)
+            }
+        }
+        if(verbose) {
+            message(paste("full", libraryNames[index]))
+        }
+        invisible(out)
+    }
+    predY <- do.call('cbind', lapply(seq(k), FUN = .predFun, lib = library$library, Y = Y, dataX = X, newX = newX, whichScreen = whichScreen, family = family, id = id, obsWeights = obsWeights, verbose = verbose, control = control, libraryNames = libraryNames))
+
+    # check for errors
+    errorsInLibrary <- apply(predY, 2, function(xx) any(is.na(xx)))
+    if(sum(errorsInLibrary) > 0) {
+        if(sum(coef[as.logical(errorsInLibrary)]) > 0) {
+            warning(paste("re-running estimation of coefficients removing failed algorithm(s) \n Orignial coefficients are: \n", coef, "\n"))
+            Z[, as.logical(errorsInLibrary)] <- 0
+            if(all(Z == 0)) {
+                stop("All algorithms dropped from library")
+            }
+            getCoef <- method$computeCoef(Z = Z, Y = tempValidOutcome, libraryNames = libraryNames, obsWeights = obsWeights[validRows], control = control, verbose = verbose)
+            coef <- getCoef$coef
+            names(coef) <- libraryNames
+        } else {
+            warning("coefficients already 0 for all failed algorithm(s)")
+        }
+    }
+
+    # compute super learner predictions on newX
+    getPred <- method$computePred(predY = predY, coef = coef, control = control)
+
+    # add names of algorithms to the predictions
+    colnames(predY) <- libraryNames
+    # clean up when errors in library
+    if(sum(errorsInCVLibrary) > 0) {
+        getCoef$cvRisk[as.logical(errorsInCVLibrary)] <- NA
+    }
+
+    # put everything together in a list
+    out <- list(call = call, libraryNames = libraryNames, SL.library = library, SL.predict = getPred, coef = coef, library.predict = predY, Z = Z, cvRisk = getCoef$cvRisk, family = family, fitLibrary = get('fitLibrary', envir = fitLibEnv), varNames = varNames, validRows = validRows, method = method, whichScreen = whichScreen, control = control, split = split, errorsInCVLibrary = errorsInCVLibrary, errorsInLibrary = errorsInLibrary)
+    class(out) <- c("SuperLearner")
+    return(out)
 }

--- a/R/SuperLearner.R
+++ b/R/SuperLearner.R
@@ -2,7 +2,7 @@
 #
 #  Created by Eric Polley on 2011-01-01.
 #
-SuperLearner2 <- function(Y, X, newX = NULL, family = gaussian(), SL.library,
+SuperLearner <- function(Y, X, newX = NULL, family = gaussian(), SL.library,
                          method = 'method.NNLS', id = NULL, verbose = FALSE, control = list(),
                          cvControl = list(), obsWeights = NULL, env = parent.frame()) {
 

--- a/R/SuperLearner.R
+++ b/R/SuperLearner.R
@@ -2,312 +2,313 @@
 #
 #  Created by Eric Polley on 2011-01-01.
 #
-SuperLearner <- function(Y, X, newX = NULL, family = gaussian(), SL.library,
+SuperLearner2 <- function(Y, X, newX = NULL, family = gaussian(), SL.library,
                          method = 'method.NNLS', id = NULL, verbose = FALSE, control = list(),
                          cvControl = list(), obsWeights = NULL, env = parent.frame()) {
 
-  # Begin timing how long SuperLearner takes to execute.
-  time_start = proc.time()
+    # Begin timing how long SuperLearner takes to execute.
+    time_start = proc.time()
 
-  if (is.character(method)) {
-    if (exists(method, mode = 'list')) {
-      method <- get(method, mode = 'list')
-    } else if (exists(method, mode = 'function')) {
-      method <- get(method, mode = 'function')()
+    if (is.character(method)) {
+        if (exists(method, mode = 'list')) {
+            method <- get(method, mode = 'list')
+        } else if (exists(method, mode = 'function')) {
+            method <- get(method, mode = 'function')()
+        }
+    } else if (is.function(method)) {
+        method <- method()
     }
-  } else if (is.function(method)) {
-    method <- method()
-  }
-  if(!is.list(method)) {
-    stop("method is not in the appropriate format. Check out help('method.template')")
-  }
-  if(!is.null(method$require)) {
-	  sapply(method$require, function(x) require(force(x), character.only = TRUE))
-	}
-  # get defaults for controls and make sure in correct format
-  control <- do.call('SuperLearner.control', control)
-  cvControl <- do.call('SuperLearner.CV.control', cvControl)
-
-  # put together the library
-  # should this be in a new environment?
-  library <- .createLibrary(SL.library)
-	.check.SL.library(library = c(unique(library$library$predAlgorithm), library$screenAlgorithm))
-
-	call <- match.call(expand.dots = TRUE)
-  # should we be checking X and newX for data.frame?
-  # data.frame not required, but most of the built-in wrappers assume a data.frame
-  if(!inherits(X, 'data.frame')) message('X is not a data frame. Check the algorithms in SL.library to make sure they are compatible with non data.frame inputs')
-  varNames <- colnames(X)
-  N <- dim(X)[1L]
-  p <- dim(X)[2L]
-  k <- nrow(library$library)
-	kScreen <- length(library$screenAlgorithm)
-	Z <- matrix(NA, N, k)
-	libraryNames <- paste(library$library$predAlgorithm, library$screenAlgorithm[library$library$rowScreen], sep="_")
-
-	# put fitLibrary in it's own environment to locate later
-	fitLibEnv <- new.env()
-	assign('fitLibrary', vector('list', length = k), envir = fitLibEnv)
-	assign('libraryNames', libraryNames, envir = fitLibEnv)
-	evalq(names(fitLibrary) <- libraryNames, envir = fitLibEnv)
-
-  # errors* records if an algorithm stops either in the CV step and/or in full data
-	errorsInCVLibrary <- rep(0, k)
-	errorsInLibrary <- rep(0, k)
-
-  # if newX is missing, use X
-	if(is.null(newX)) {
-		newX <- X
-	}
-  # Are these checks still required?
-	if(!identical(colnames(X), colnames(newX))) {
-		stop("The variable names and order in newX must be identical to the variable names and order in X")
-	}
-	if (sum(is.na(X)) > 0 | sum(is.na(newX)) > 0 | sum(is.na(Y)) > 0) {
-		stop("missing data is currently not supported. Check Y, X, and newX for missing values")
-	}
-	if (!is.numeric(Y)) {
-		stop("the outcome Y must be a numeric vector")
-	}
-  # family can be either character or function, so these lines put everything together (code from glm())
-	if(is.character(family))
-		family <- get(family, mode="function", envir=parent.frame())
-	if(is.function(family))
-		family <- family()
-	if (is.null(family$family)) {
-		print(family)
-		stop("'family' not recognized")
-	}
-
-	if (family$family != "binomial" & isTRUE("cvAUC" %in% method$require)){
-		stop("'method.AUC' is designed for the 'binomial' family only")
-	}
-
-  # create CV folds
-	validRows <- CVFolds(N = N, id = id, Y = Y, cvControl = cvControl)
-
-  # test id
-	if(is.null(id)) {
-		id <- seq(N)
-	}
-	if(!identical(length(id), N)) {
-		stop("id vector must have the same dimension as Y")
-	}
-  # test observation weights
-	if(is.null(obsWeights)) {
-		obsWeights <- rep(1, N)
-	}
-	if(!identical(length(obsWeights), N)) {
-		stop("obsWeights vector must have the same dimension as Y")
-	}
-
-  # create function for the cross-validation step:
-	.crossValFUN <- function(valid, Y, dataX, id, obsWeights, library, kScreen, k, p, libraryNames) {
-	  tempLearn <- dataX[-valid, , drop = FALSE]
-	  tempOutcome <- Y[-valid]
-	  tempValid <- dataX[valid, , drop = FALSE]
-	  tempWhichScreen <- matrix(NA, nrow = kScreen, ncol = p)
-	  tempId <- id[-valid]
-	  tempObsWeights <- obsWeights[-valid]
-
-    # should this be converted to a lapply also?
-		for(s in seq(kScreen)) {
-		  screen_fn = get(library$screenAlgorithm[s], envir = env)
-			testScreen <- try(do.call(screen_fn, list(Y = tempOutcome, X = tempLearn, family = family, id = tempId, obsWeights = tempObsWeights)))
-			if(inherits(testScreen, "try-error")) {
-				warning(paste("replacing failed screening algorithm,", library$screenAlgorithm[s], ", with All()", "\n "))
-				tempWhichScreen[s, ] <- TRUE
-			} else {
-				tempWhichScreen[s, ] <- testScreen
-			}
-			if(verbose) {
-				message(paste("Number of covariates in ", library$screenAlgorithm[s], " is: ", sum(tempWhichScreen[s, ]), sep = ""))
-			}
-		} #end screen
-
-    # should this be converted to a lapply also?
-    out <- matrix(NA, nrow = nrow(tempValid), ncol = k)
-		for(s in seq(k)) {
-		  pred_fn = get(library$library$predAlgorithm[s], envir = env)
-			testAlg <- try(do.call(pred_fn, list(Y = tempOutcome, X = subset(tempLearn, select = tempWhichScreen[library$library$rowScreen[s], ], drop=FALSE), newX = subset(tempValid, select = tempWhichScreen[library$library$rowScreen[s], ], drop=FALSE), family = family, id = tempId, obsWeights = tempObsWeights)))
-			if(inherits(testAlg, "try-error")) {
-				warning(paste("Error in algorithm", library$library$predAlgorithm[s], "\n  The Algorithm will be removed from the Super Learner (i.e. given weight 0) \n" ))
-        # errorsInCVLibrary[s] <<- 1
-			} else {
-				out[, s] <- testAlg$pred
-			}
-			if (verbose) message(paste("CV", libraryNames[s]))
-		} #end library
-	  invisible(out)
-	}
-  # the lapply performs the cross-validation steps to create Z
-  # additional steps to put things in the correct order
-  # rbind unlists the output from lapply
-  # need to unlist folds to put the rows back in the correct order
-	time_train_start = proc.time()
-
-	Z[unlist(validRows, use.names = FALSE), ] <- do.call('rbind', lapply(validRows, FUN = .crossValFUN, Y = Y, dataX = X, id = id, obsWeights = obsWeights, library = library, kScreen = kScreen, k = k, p = p, libraryNames = libraryNames))
-
-  # Check for errors. If any algorithms had errors, replace entire column with
-  # 0 even if error is only in one fold.
-  errorsInCVLibrary <- apply(Z, 2, function(x) anyNA(x))
-  if (sum(errorsInCVLibrary) > 0) {
-	  Z[, as.logical(errorsInCVLibrary)] <- 0
-	}
-	if (all(Z == 0)) {
-	 stop("All algorithms dropped from library")
-	}
-
-  # Compute weights for each algorithm in library.
-  getCoef <- method$computeCoef(Z = Z, Y = Y, libraryNames = libraryNames,
-                                obsWeights = obsWeights, control = control,
-                                verbose = verbose,
-                                errorsInLibrary = errorsInCVLibrary)
-  coef <- getCoef$coef
-  names(coef) <- libraryNames
-
-  time_train = proc.time() - time_train_start
-
-  # Set a default in case the method does not return the optimizer result.
-  if (!("optimizer" %in% names(getCoef))) {
-    getCoef["optimizer"] <- NA
-  }
-
-  # now fit all algorithms in library on entire learning data set and predict on newX
-  m <- dim(newX)[1L]
-  predY <- matrix(NA, nrow = m, ncol = k)
-  # whichScreen <- matrix(NA, nrow = kScreen, ncol = p)
-
-  .screenFun <- function(fun, list) {
-    screen_fn = get(fun, envir = env)
-    testScreen <- try(do.call(screen_fn, list))
-    if (inherits(testScreen, "try-error")) {
-  	  warning(paste("replacing failed screening algorithm,", fun, ", with All() in full data", "\n "))
-  	  out <- rep(TRUE, ncol(list$X))
-  	} else {
-  	  out <- testScreen
+    if(!is.list(method)) {
+        stop("method is not in the appropriate format. Check out help('method.template')")
     }
+    if(!is.null(method$require)) {
+        sapply(method$require, function(x) require(force(x), character.only = TRUE))
+    }
+    # get defaults for controls and make sure in correct format
+    control <- do.call('SuperLearner.control', control)
+    cvControl <- do.call('SuperLearner.CV.control', cvControl)
+
+    # put together the library
+    # should this be in a new environment?
+    library <- .createLibrary(SL.library)
+    .check.SL.library(library = c(unique(library$library$predAlgorithm), library$screenAlgorithm))
+
+    call <- match.call(expand.dots = TRUE)
+    # should we be checking X and newX for data.frame?
+    # data.frame not required, but most of the built-in wrappers assume a data.frame
+    if(!inherits(X, 'data.frame')) message('X is not a data frame. Check the algorithms in SL.library to make sure they are compatible with non data.frame inputs')
+    varNames <- colnames(X)
+    N <- dim(X)[1L]
+    p <- dim(X)[2L]
+    k <- nrow(library$library)
+    kScreen <- length(library$screenAlgorithm)
+    Z <- matrix(NA, N, k)
+    libraryNames <- paste(library$library$predAlgorithm, library$screenAlgorithm[library$library$rowScreen], sep="_")
+
+    # put fitLibrary in it's own environment to locate later
+    fitLibEnv <- new.env()
+    assign('fitLibrary', vector('list', length = k), envir = fitLibEnv)
+    assign('libraryNames', libraryNames, envir = fitLibEnv)
+    evalq(names(fitLibrary) <- libraryNames, envir = fitLibEnv)
+
+    # errors* records if an algorithm stops either in the CV step and/or in full data
+    errorsInCVLibrary <- rep(0, k)
+    errorsInLibrary <- rep(0, k)
+
+    # if newX is missing, use X
+    if(is.null(newX)) {
+        newX <- X
+    }
+    # Are these checks still required?
+    if(!identical(colnames(X), colnames(newX))) {
+        stop("The variable names and order in newX must be identical to the variable names and order in X")
+    }
+    if (sum(is.na(X)) > 0 | sum(is.na(newX)) > 0 | sum(is.na(Y)) > 0) {
+        stop("missing data is currently not supported. Check Y, X, and newX for missing values")
+    }
+    if (!is.numeric(Y)) {
+        stop("the outcome Y must be a numeric vector")
+    }
+    # family can be either character or function, so these lines put everything together (code from glm())
+    if(is.character(family))
+        family <- get(family, mode="function", envir=parent.frame())
+    if(is.function(family))
+        family <- family()
+    if (is.null(family$family)) {
+        print(family)
+        stop("'family' not recognized")
+    }
+
+    if (family$family != "binomial" & isTRUE("cvAUC" %in% method$require)){
+        stop("'method.AUC' is designed for the 'binomial' family only")
+    }
+
+    # create CV folds
+    validRows <- CVFolds(N = N, id = id, Y = Y, cvControl = cvControl)
+
+    # test id
+    if(is.null(id)) {
+        id <- seq(N)
+    }
+    if(!identical(length(id), N)) {
+        stop("id vector must have the same dimension as Y")
+    }
+    # test observation weights
+    if(is.null(obsWeights)) {
+        obsWeights <- rep(1, N)
+    }
+    if(!identical(length(obsWeights), N)) {
+        stop("obsWeights vector must have the same dimension as Y")
+    }
+
+    # create function for the cross-validation step:
+    .crossValFUN <- function(valid, Y, dataX, id, obsWeights, library, kScreen, k, p, libraryNames) {
+        tempLearn <- dataX[-valid, , drop = FALSE]
+        tempOutcome <- Y[-valid]
+        tempValid <- dataX[valid, , drop = FALSE]
+        tempWhichScreen <- matrix(NA, nrow = kScreen, ncol = p)
+        tempId <- id[-valid]
+        tempObsWeights <- obsWeights[-valid]
+
+        # should this be converted to a lapply also?
+        for(s in seq(kScreen)) {
+            screen_fn = get(library$screenAlgorithm[s], envir = env)
+            testScreen <- try(do.call(screen_fn, list(Y = tempOutcome, X = tempLearn, family = family, id = tempId, obsWeights = tempObsWeights)))
+            if(inherits(testScreen, "try-error")) {
+                warning(paste("replacing failed screening algorithm,", library$screenAlgorithm[s], ", with All()", "\n "))
+                tempWhichScreen[s, ] <- TRUE
+            } else {
+                tempWhichScreen[s, ] <- testScreen
+            }
+            if(verbose) {
+                message(paste("Number of covariates in ", library$screenAlgorithm[s], " is: ", sum(tempWhichScreen[s, ]), sep = ""))
+            }
+        } #end screen
+
+        # should this be converted to a lapply also?
+        out <- matrix(NA, nrow = nrow(tempValid), ncol = k)
+        for(s in seq(k)) {
+            pred_fn = get(library$library$predAlgorithm[s], envir = env)
+            testAlg <- try(do.call(pred_fn, list(Y = tempOutcome, X = subset(tempLearn, select = tempWhichScreen[library$library$rowScreen[s], ], drop=FALSE), newX = subset(tempValid, select = tempWhichScreen[library$library$rowScreen[s], ], drop=FALSE), family = family, id = tempId, obsWeights = tempObsWeights)))
+            if(inherits(testAlg, "try-error")) {
+                warning(paste("Error in algorithm", library$library$predAlgorithm[s], "\n  The Algorithm will be removed from the Super Learner (i.e. given weight 0) \n" ))
+            # errorsInCVLibrary[s] <<- 1
+            } else {
+                out[, s] <- testAlg$pred
+            }
+            if (verbose) message(paste("CV", libraryNames[s]))
+        } #end library
+        invisible(out)
+    }
+    # the lapply performs the cross-validation steps to create Z
+    # additional steps to put things in the correct order
+    # rbind unlists the output from lapply
+    # need to unlist folds to put the rows back in the correct order
+    time_train_start = proc.time()
+
+    Z[unlist(validRows, use.names = FALSE), ] <- do.call('rbind', lapply(validRows, FUN = .crossValFUN, Y = Y, dataX = X, id = id, obsWeights = obsWeights, library = library, kScreen = kScreen, k = k, p = p, libraryNames = libraryNames))
+
+    # Check for errors. If any algorithms had errors, replace entire column with
+    # 0 even if error is only in one fold.
+    errorsInCVLibrary <- apply(Z, 2, function(x) anyNA(x))
+    if (sum(errorsInCVLibrary) > 0) {
+        Z[, as.logical(errorsInCVLibrary)] <- 0
+    }
+    if (all(Z == 0)) {
+        stop("All algorithms dropped from library")
+    }
+
+    # Compute weights for each algorithm in library.
+    getCoef <- method$computeCoef(Z = Z, Y = Y, libraryNames = libraryNames,
+                                  obsWeights = obsWeights, control = control,
+                                  verbose = verbose,
+                                  errorsInLibrary = errorsInCVLibrary)
+    coef <- getCoef$coef
+    names(coef) <- libraryNames
+
+    time_train = proc.time() - time_train_start
+
+    # Set a default in case the method does not return the optimizer result.
+    if (!("optimizer" %in% names(getCoef))) {
+        getCoef["optimizer"] <- NA
+    }
+
+    # now fit all algorithms in library on entire learning data set and predict on newX
+    m <- dim(newX)[1L]
+    predY <- matrix(NA, nrow = m, ncol = k)
+    # whichScreen <- matrix(NA, nrow = kScreen, ncol = p)
+
+    .screenFun <- function(fun, list) {
+        screen_fn = get(fun, envir = env)
+        testScreen <- try(do.call(screen_fn, list))
+        if (inherits(testScreen, "try-error")) {
+            warning(paste("replacing failed screening algorithm,", fun, ", with All() in full data", "\n "))
+            out <- rep(TRUE, ncol(list$X))
+        } else {
+            out <- testScreen
+        }
+        return(out)
+    }
+
+    time_predict_start = proc.time()
+
+    whichScreen <- sapply(library$screenAlgorithm, FUN = .screenFun, list = list(Y = Y, X = X, family = family, id = id, obsWeights = obsWeights), simplify = FALSE)
+    whichScreen <- do.call(rbind, whichScreen)
+
+    # change to sapply?
+    # for(s in 1:k) {
+    #   testAlg <- try(do.call(library$library$predAlgorithm[s], list(Y = Y, X = subset(X, select = whichScreen[library$library$rowScreen[s], ], drop=FALSE), newX = subset(newX, select = whichScreen[library$library$rowScreen[s], ], drop=FALSE), family = family, id = id, obsWeights = obsWeights)))
+    #   if(inherits(testAlg, "try-error")) {
+    #     warning(paste("Error in algorithm", library$library$predAlgorithm[s], " on full data", "\n  The Algorithm will be removed from the Super Learner (i.e. given weight 0) \n" ))
+    #     errorsInLibrary[s] <- 1
+    #   } else {
+    #     predY[, s] <- testAlg$pred
+    #   }
+    #   if(control$saveFitLibrary) {
+    #     fitLibrary[[s]] <- testAlg$fit
+    #   }
+    #   if(verbose) {
+    #     message(paste("full", libraryNames[s]))
+    #   }
+    # }
+    .predFun <- function(index, lib, Y, dataX, newX, whichScreen, family, id, obsWeights, verbose, control, libraryNames) {
+        pred_fn = get(lib$predAlgorithm[index], envir = env)
+        testAlg <- try(do.call(pred_fn, list(Y = Y,
+                                             X = subset(dataX,
+                                                        select = whichScreen[lib$rowScreen[index], ], drop=FALSE),
+                                             newX = subset(newX, select = whichScreen[lib$rowScreen[index], ], drop=FALSE),
+                                             family = family, id = id, obsWeights = obsWeights)))
+        # testAlg <- try(do.call(lib$predAlgorithm[index], list(Y = Y, X = dataX[, whichScreen[lib$rowScreen[index], drop = FALSE]], newX = newX[, whichScreen[lib$rowScreen[index], drop = FALSE]], family = family, id = id, obsWeights = obsWeights)))
+        if (inherits(testAlg, "try-error")) {
+            warning(paste("Error in algorithm", lib$predAlgorithm[index], " on full data", "\n  The Algorithm will be removed from the Super Learner (i.e. given weight 0) \n" ))
+            out <- rep.int(NA, times = nrow(newX))
+        } else {
+            out <- testAlg$pred
+            if (control$saveFitLibrary) {
+                eval(bquote(fitLibrary[[.(index)]] <- .(testAlg$fit)), envir = fitLibEnv)
+            }
+        }
+        if (verbose) {
+            message(paste("full", libraryNames[index]))
+        }
+        invisible(out)
+    }
+
+
+    predY <- do.call('cbind', lapply(seq(k), FUN = .predFun,
+                                     lib = library$library, Y = Y, dataX = X,
+                                     newX = newX, whichScreen = whichScreen,
+                                     family = family, id = id,
+                                     obsWeights = obsWeights, verbose = verbose,
+                                     control = control,
+                                     libraryNames = libraryNames))
+
+    # check for errors
+    errorsInLibrary <- apply(predY, 2, function(algorithm) anyNA(algorithm))
+    if (sum(errorsInLibrary) > 0) {
+        if (sum(coef[as.logical(errorsInLibrary)]) > 0) {
+            warning(paste0("Re-running estimation of coefficients removing failed algorithm(s)\n",
+                           "Original coefficients are: \n", paste(coef, collapse = ", "), "\n"))
+            Z[, as.logical(errorsInLibrary)] <- 0
+            if (all(Z == 0)) {
+                stop("All algorithms dropped from library")
+            }
+            getCoef <- method$computeCoef(Z = Z, Y = Y, libraryNames = libraryNames,
+                                          obsWeights = obsWeights, control = control,
+                                          verbose = verbose,
+                                          errorsInLibrary = errorsInLibrary)
+            coef <- getCoef$coef
+            names(coef) <- libraryNames
+        } else {
+            warning("Coefficients already 0 for all failed algorithm(s)")
+        }
+    }
+
+    # Compute super learner predictions on newX.
+    getPred <- method$computePred(predY = predY, coef = coef, control = control)
+
+    time_predict = proc.time() - time_predict_start
+
+    # Add names of algorithms to the predictions.
+    colnames(predY) <- libraryNames
+
+    # Clean up when errors in library.
+    if(sum(errorsInCVLibrary) > 0) {
+        getCoef$cvRisk[as.logical(errorsInCVLibrary)] <- NA
+    }
+
+    # Finish timing the full SuperLearner execution.
+    time_end = proc.time()
+
+    # Compile execution times.
+    times = list(everything = time_end - time_start,
+                 train = time_train,
+                 predict = time_predict)
+
+    # Put everything together in a list.
+    out <- list(
+        call = call,
+        libraryNames = libraryNames,
+        SL.library = library,
+        SL.predict = getPred,
+        coef = coef,
+        library.predict = predY,
+        Z = Z,
+        cvRisk = getCoef$cvRisk,
+        family = family,
+        fitLibrary = get('fitLibrary', envir = fitLibEnv),
+        varNames = varNames,
+        validRows = validRows,
+        method = method,
+        whichScreen = whichScreen,
+        control = control,
+        cvControl = cvControl,
+        errorsInCVLibrary = errorsInCVLibrary,
+        errorsInLibrary = errorsInLibrary,
+        metaOptimizer = getCoef$optimizer,
+        env = env,
+        times = times
+    )
+    class(out) <- c("SuperLearner")
     return(out)
-  }
-
-  time_predict_start = proc.time()
-
-  whichScreen <- t(sapply(library$screenAlgorithm, FUN = .screenFun, list = list(Y = Y, X = X, family = family, id = id, obsWeights = obsWeights)))
-
-  # change to sapply?
-  # for(s in 1:k) {
-  #   testAlg <- try(do.call(library$library$predAlgorithm[s], list(Y = Y, X = subset(X, select = whichScreen[library$library$rowScreen[s], ], drop=FALSE), newX = subset(newX, select = whichScreen[library$library$rowScreen[s], ], drop=FALSE), family = family, id = id, obsWeights = obsWeights)))
-  #   if(inherits(testAlg, "try-error")) {
-  #     warning(paste("Error in algorithm", library$library$predAlgorithm[s], " on full data", "\n  The Algorithm will be removed from the Super Learner (i.e. given weight 0) \n" ))
-  #     errorsInLibrary[s] <- 1
-  #   } else {
-  #     predY[, s] <- testAlg$pred
-  #   }
-  #   if(control$saveFitLibrary) {
-  #     fitLibrary[[s]] <- testAlg$fit
-  #   }
-  #   if(verbose) {
-  #     message(paste("full", libraryNames[s]))
-  #   }
-  # }
-  .predFun <- function(index, lib, Y, dataX, newX, whichScreen, family, id, obsWeights, verbose, control, libraryNames) {
-    pred_fn = get(lib$predAlgorithm[index], envir = env)
-    testAlg <- try(do.call(pred_fn, list(Y = Y,
-                                         X = subset(dataX,
-                                                    select = whichScreen[lib$rowScreen[index], ], drop=FALSE),
-                                         newX = subset(newX, select = whichScreen[lib$rowScreen[index], ], drop=FALSE),
-                                         family = family, id = id, obsWeights = obsWeights)))
-    # testAlg <- try(do.call(lib$predAlgorithm[index], list(Y = Y, X = dataX[, whichScreen[lib$rowScreen[index], drop = FALSE]], newX = newX[, whichScreen[lib$rowScreen[index], drop = FALSE]], family = family, id = id, obsWeights = obsWeights)))
-    if (inherits(testAlg, "try-error")) {
-      warning(paste("Error in algorithm", lib$predAlgorithm[index], " on full data", "\n  The Algorithm will be removed from the Super Learner (i.e. given weight 0) \n" ))
-      out <- rep.int(NA, times = nrow(newX))
-    } else {
-      out <- testAlg$pred
-      if (control$saveFitLibrary) {
-        eval(bquote(fitLibrary[[.(index)]] <- .(testAlg$fit)), envir = fitLibEnv)
-      }
-    }
-    if (verbose) {
-      message(paste("full", libraryNames[index]))
-    }
-    invisible(out)
-  }
-
-
-  predY <- do.call('cbind', lapply(seq(k), FUN = .predFun,
-                                   lib = library$library, Y = Y, dataX = X,
-                                   newX = newX, whichScreen = whichScreen,
-                                   family = family, id = id,
-                                   obsWeights = obsWeights, verbose = verbose,
-                                   control = control,
-                                   libraryNames = libraryNames))
-
-  # check for errors
-  errorsInLibrary <- apply(predY, 2, function(algorithm) anyNA(algorithm))
-  if (sum(errorsInLibrary) > 0) {
-	  if (sum(coef[as.logical(errorsInLibrary)]) > 0) {
-		  warning(paste0("Re-running estimation of coefficients removing failed algorithm(s)\n",
-		                 "Original coefficients are: \n", paste(coef, collapse = ", "), "\n"))
-		  Z[, as.logical(errorsInLibrary)] <- 0
-		  if (all(Z == 0)) {
-			  stop("All algorithms dropped from library")
-		  }
-      getCoef <- method$computeCoef(Z = Z, Y = Y, libraryNames = libraryNames,
-                                    obsWeights = obsWeights, control = control,
-                                    verbose = verbose,
-                                    errorsInLibrary = errorsInLibrary)
-      coef <- getCoef$coef
-      names(coef) <- libraryNames
-	  } else {
-		  warning("Coefficients already 0 for all failed algorithm(s)")
-	  }
-  }
-
-  # Compute super learner predictions on newX.
-  getPred <- method$computePred(predY = predY, coef = coef, control = control)
-
-	time_predict = proc.time() - time_predict_start
-
-	# Add names of algorithms to the predictions.
-	colnames(predY) <- libraryNames
-
-	# Clean up when errors in library.
-	if(sum(errorsInCVLibrary) > 0) {
-		getCoef$cvRisk[as.logical(errorsInCVLibrary)] <- NA
-	}
-
-	# Finish timing the full SuperLearner execution.
-	time_end = proc.time()
-
-	# Compile execution times.
-	times = list(everything = time_end - time_start,
-	             train = time_train,
-	             predict = time_predict)
-
-  # Put everything together in a list.
-	out <- list(
-	    call = call,
-	    libraryNames = libraryNames,
-	    SL.library = library,
-	    SL.predict = getPred,
-	    coef = coef,
-	    library.predict = predY,
-	    Z = Z,
-	    cvRisk = getCoef$cvRisk,
-	    family = family,
-	    fitLibrary = get('fitLibrary', envir = fitLibEnv),
-	    varNames = varNames,
-	    validRows = validRows,
-	    method = method,
-	    whichScreen = whichScreen,
-	    control = control,
-	    cvControl = cvControl,
-	    errorsInCVLibrary = errorsInCVLibrary,
-	    errorsInLibrary = errorsInLibrary,
-	    metaOptimizer = getCoef$optimizer,
-	    env = env,
-	    times = times
-	  )
-	class(out) <- c("SuperLearner")
-	return(out)
 }

--- a/R/mcSuperLearner.R
+++ b/R/mcSuperLearner.R
@@ -194,7 +194,8 @@ mcSuperLearner <- function(Y, X, newX = NULL, family = gaussian(), SL.library,
   }
 
   time_predict = system.time({
-    whichScreen <- t(sapply(library$screenAlgorithm, FUN = .screenFun, list = list(Y = Y, X = X, family = family, id = id, obsWeights = obsWeights)))
+    whichScreen <- sapply(library$screenAlgorithm, FUN = .screenFun, list = list(Y = Y, X = X, family = family, id = id, obsWeights = obsWeights), simplify = FALSE)
+    whichScreen <- do.call(rbind, whichScreen)
 
     # change to sapply?
     # for(s in 1:k) {

--- a/R/snowSuperLearner.R
+++ b/R/snowSuperLearner.R
@@ -196,11 +196,12 @@ snowSuperLearner <- function(cluster, Y, X, newX = NULL, family = gaussian(), SL
 
   time_predict = system.time({
 
-    if (length(library$screenAlgorithm) < 2) {
-      whichScreen <- t(sapply(library$screenAlgorithm, FUN = .screenFun, list = list(Y = Y, X = X, family = family, id = id, obsWeights = obsWeights)))
+    whichScreen <- if (length(library$screenAlgorithm) < 2) {
+      sapply(library$screenAlgorithm, FUN = .screenFun, list = list(Y = Y, X = X, family = family, id = id, obsWeights = obsWeights), simplify = FALSE)
     } else {
-      whichScreen <- t(parallel::parSapply(cl = cluster, X = library$screenAlgorithm, FUN = .screenFun, list = list(Y = Y, X = X, family = family, id = id, obsWeights = obsWeights)))
+      parallel::parSapply(cl = cluster, X = library$screenAlgorithm, FUN = .screenFun, list = list(Y = Y, X = X, family = family, id = id, obsWeights = obsWeights), simplify = FALSE)
     }
+    whichScreen <- do.call(rbind, whichScreen)
     # change to sapply?
     # for(s in 1:k) {
     #   testAlg <- try(do.call(library$library$predAlgorithm[s], list(Y = Y, X = subset(X, select = whichScreen[library$library$rowScreen[s], ], drop=FALSE), newX = subset(newX, select = whichScreen[library$library$rowScreen[s], ], drop=FALSE), family = family, id = id, obsWeights = obsWeights)))

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -5,7 +5,7 @@ Version: 2.0-23
 Date: 2017-11-29
 * fixed transformation of outcome in SL.dbarts for binomial family
 * SampleSplitSuperLearner(): support validation sample size of 1 when observation's row number is passed in via 'split'.
-* Fixed case where single-column X causes failure in SuperLearner(), snowSuperLearner(), mcSuperLearner, SampleSplitSuperLearner()
+* Fixed case where single-column X causes failure in SuperLearner(), snowSuperLearner(), mcSuperLearner(), SampleSplitSuperLearner()
 
 ---
 Version: 2.0-22

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -2,9 +2,10 @@
 
 ---
 Version: 2.0-23
-Date: 2017-11-07
+Date: 2017-11-29
 * fixed transformation of outcome in SL.dbarts for binomial family
 * SampleSplitSuperLearner(): support validation sample size of 1 when observation's row number is passed in via 'split'.
+* Fixed case where single-column X causes failure in SuperLearner(), snowSuperLearner(), mcSuperLearner, SampleSplitSuperLearner()
 
 ---
 Version: 2.0-22


### PR DESCRIPTION
If provided with a single-column X, `SuperLearner()`, `snowSuperLearner()`, `mcSuperLearner()`, and `SampleSplitSuperLearner()` would fail ("all algorithms dropped from library") because `whichScreen` was not simplified as desired (`t(sapply(...))` led to an array rather than a matrix, in this case).  This bug has been fixed. Some tabbing and extra spaces have been cleaned up in `SuperLearner()` and `SampleSplitSuperLearner()` (sorry for the big diffs).