### PR TITLE
add a tolerance threshold for duplicated

### DIFF
--- a/R/method.R
+++ b/R/method.R
@@ -214,7 +214,9 @@ method.CC_LS <- function() {
                        "Removing from super learner."))
     }
     # check for duplicated columns
-    dupCols <- which(duplicated(Z, MARGIN = 2))
+    # set a tolerance level to avoid numerical instability
+    tol <- 8
+    dupCols <- which(duplicated(round(Z, tol), MARGIN = 2))
     anyDupCols <- length(dupCols) > 0 
     if(anyDupCols){
         # if present, throw warning identifying learners
@@ -271,7 +273,9 @@ method.CC_nloglik <- function() {
   }
   computeCoef = function(Z, Y, libraryNames, obsWeights, control, verbose, ...) {
     # check for duplicated columns
-    dupCols <- which(duplicated(Z, MARGIN = 2))
+    # set a tolerance 
+    tol <- 8
+    dupCols <- which(duplicated(round(Z, tol), MARGIN = 2))
     anyDupCols <- length(dupCols) > 0 
     modZ <- Z
     if(anyDupCols){


### PR DESCRIPTION
If a method's results are not *exactly* `duplicated`, then numerical difficulties still arise (e.g., `SL.glm` with intercept-only model may provide a mean estimate to a different level of precision than `SL.mean` though `duplicated` does not pick up on this). 

This pull request adds a tolerance level by rounding the columns of `Z` before checking for duplicates. I've set the default to 8 digits, which seems like a reasonable level, though further testing may reveal a more/less stringent threshold will suffice. 