### PR TITLE
Allow listWrappers() to be used without loading package

### DIFF
--- a/R/listWrapper.R
+++ b/R/listWrapper.R
@@ -1,5 +1,5 @@
 listWrappers <- function(what = "both") {
-	everything <- getNamespaceExports("SuperLearner")
+	everything <- sort(getNamespaceExports("SuperLearner"))
 	if(what == "both") {
 		message("All prediction algorithm wrappers in SuperLearner:\n")
 		print(everything[grepl(pattern="^[S]L", everything)])

--- a/R/listWrapper.R
+++ b/R/listWrapper.R
@@ -1,23 +1,24 @@
 listWrappers <- function(what = "both") {
+	everything <- getNamespaceExports("SuperLearner")
 	if(what == "both") {
 		message("All prediction algorithm wrappers in SuperLearner:\n")
-		print(ls("package:SuperLearner", pattern="^[S]L"))
+		print(everything[grepl(pattern="^[S]L", everything)])
 		message("\nAll screening algorithm wrappers in SuperLearner:\n")
 		print("All")
-		print(ls("package:SuperLearner", pattern="screen"))
+		print(everything[grepl(pattern="screen", everything)])
 	} else if(what == "SL") {
 		message("All prediction algorithm wrappers in SuperLearner:\n")
-		print(ls("package:SuperLearner", pattern="^[S]L"))
+		print(everything[grepl(pattern="^[S]L", everything)])
 	} else if(what == "screen") {
 		message("All screening algorithm wrappers in SuperLearner:\n")
 		print("All")
-		print(ls("package:SuperLearner", pattern="screen"))
+		print(everything[grepl(pattern="screen", everything)])
 	} else if(what == 'method') {
 	  message("All methods in SuperLearner package:\n")
-		print(ls("package:SuperLearner", pattern="^method"))
+		print(everything[grepl(pattern="^method", everything)])
 	} else {
 		message("All functions in SuperLearner:\n")
-		print(ls("package:SuperLearner"))
+		print(everything)
 	}
-	invisible(ls("package:SuperLearner"))
+	invisible(everything)
 }


### PR DESCRIPTION
These edits allow `listWrappers()` to be successfully called when `SuperLearner` isn't loaded, i.e., with `SuperLearner::listWrappers()`. This doesn't affect the functionality when it is loaded but allows users to see what options are available in `SuperLearner` without loading it. This may be helpful when `SuperLearner` functions are called from another package that doesn't require `SuperLearner` to be loaded and users may want to view the available algorithms and methods.