### PR TITLE
Return cross-validated models fits

### DIFF
--- a/R/control.R
+++ b/R/control.R
@@ -2,12 +2,14 @@
 # 
 # Created by Eric Polley on 2011-01-03.
 # 
-SuperLearner.control <- function(saveFitLibrary = TRUE, trimLogit = 0.001) {
+SuperLearner.control <- function(saveFitLibrary = TRUE, 
+                                 saveCVFitLibrary = FALSE,
+                                 trimLogit = 0.001) {
   if(trimLogit > 0.5) {
     warning('trimLogit must be less than 0.5, will replace with trimLogit = 0.001')
     trimLogit <- 0.001
   }
-  list(saveFitLibrary = saveFitLibrary, trimLogit = trimLogit)
+  list(saveFitLibrary = saveFitLibrary, trimLogit = trimLogit, saveCVFitLibrary = saveCVFitLibrary)
 }
 
 SuperLearner.CV.control <- function(V = 10L, stratifyCV = FALSE, shuffle = TRUE, validRows = NULL){

--- a/man/SuperLearner.Rd
+++ b/man/SuperLearner.Rd
@@ -91,6 +91,10 @@ Returns the \code{family} value from above
   \item{fitLibrary}{
 A list with the fitted objects for each algorithm in \code{SL.library} on the full training data set.
 }
+  \item{cvFitLibrary}{
+A list with fitted objects for each algorithm in \code{SL.library} on each of 
+\code{V} different training data sets. 
+}
   \item{varNames}{
 A character vector with the names of the variables in \code{X}.
 }

--- a/man/SuperLearner.control.Rd
+++ b/man/SuperLearner.control.Rd
@@ -14,6 +14,9 @@ SuperLearner.control(saveFitLibrary = TRUE, trimLogit = 0.001)
   \item{saveFitLibrary}{
 Logical. Should the fit for each algorithm be saved in the output from \code{SuperLearner}.
 }
+  \item{saveCVFitLibrary}{
+Logical. Should cross-validated fits for each algorithm be saved in the output from \code{SuperLearner}.
+}
   \item{trimLogit}{
 number between 0.0 and 0.5. What level to truncate the logit transformation to maintain a bounded loss function when using the NNloglik method.
 }


### PR DESCRIPTION
## Reason for pull request

It is often useful in my research to be able to predict from cross-validated algorithm fits (i.e., the `V` cross-validated fits for each of the `K` learners). In particular, I hope to include pseudo-cross-validated standard error estimates in an update of my [`drtmle`](https://github.com/benkeser/drtmle) package. 

## Structure of pull request

I added an option `saveCVFitLibrary` to `control` similar to `saveFitLibrary` that controls whether these are returned. If they are returned it is in the `cvFitLibrary` entry in the output of a call to `SuperLearner`. 

I believe I have added all relevant documentation to `SuperLearner.control` and `SuperLearner`. 

I've tried to be relatively memory efficient in creating objects that hold a lot of model fits. These fits are only stored beyond the original `SuperLearner` code if `saveCVFitLibrary = TRUE`. Otherwise, this PR shouldn't be any more memory hungry than the original code. 
